### PR TITLE
using os temp dir and fixing the id geneneration

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,6 @@
+## 3.2.5
+* use the OS temp dir for remote doc testing instead of project root dir
+* use the amorphic object id as the unique identifier in S3
 ## 3.2.4
 * use a more unique keyname for remote doc configs 
 ## 3.2.3

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -157,7 +157,7 @@ module.exports = function (PersistObjectTemplate) {
                     const documentBody = remoteObject;
 
                     // unique identifier to find the object we're saving in the remote store
-                    const objectKey = `${defineProperty.remoteKeyBase}/${uniqueIdentifier}`;
+                    const objectKey = `${defineProperty.remoteKeyBase}-${uniqueIdentifier}`;
 
                     const bucket = this.bucketName;
 

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -157,7 +157,7 @@ module.exports = function (PersistObjectTemplate) {
                     const documentBody = remoteObject;
 
                     // unique identifier to find the object we're saving in the remote store
-                    const objectKey = `${defineProperty.remoteKeyBase}-${uniqueIdentifier}`;
+                    const objectKey = `${defineProperty.remoteKeyBase}/${uniqueIdentifier}`;
 
                     const bucket = this.bucketName;
 

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -1,6 +1,5 @@
 import { RemoteDocService } from '../remote-doc/RemoteDocService';
 import { PersistorTransaction } from '../types/PersistorTransaction';
-import * as uuidv4 from 'uuid/v4';
 
 module.exports = function (PersistObjectTemplate) {
 
@@ -147,7 +146,7 @@ module.exports = function (PersistObjectTemplate) {
                 dataSaved[foreignKey] = pojo[foreignKey] || 'null';
 
             } else if (defineProperty.isRemoteObject && defineProperty.isRemoteObject === true) {
-                const uniqueIdentifier = uuidv4();
+                const uniqueIdentifier = obj._id;
 
                 const remoteObject: string = obj[prop];
 
@@ -158,7 +157,7 @@ module.exports = function (PersistObjectTemplate) {
                     const documentBody = remoteObject;
 
                     // unique identifier to find the object we're saving in the remote store
-                    const objectKey = defineProperty.__remoteObjectKey__ || `${defineProperty.remoteKeyBase}-${uniqueIdentifier}`;
+                    const objectKey = `${defineProperty.remoteKeyBase}-${uniqueIdentifier}`;
 
                     const bucket = this.bucketName;
 

--- a/components/persistor/lib/remote-doc/remote-doc-clients/LocalStorageDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-clients/LocalStorageDocClient.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { RemoteDocClient } from '../remote-doc-types/index';
 
 /**
@@ -14,7 +15,7 @@ export class LocalStorageDocClient implements RemoteDocClient {
     }
 
     init(): this {
-        let remoteDocStorageDir = path.join(path.dirname(require.main.filename), 'remoteDocStorageDir');
+        let remoteDocStorageDir = path.join(os.tmpdir(), 'remoteDocStorageDir');
 
         if (!fs.existsSync(remoteDocStorageDir)) {
             fs.mkdirSync(remoteDocStorageDir);

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from mongodb",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "3.2.4",
+    "version": "3.2.5",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
- only write to tmp file for safety
- ID generation was failing for the case where there was a one => many relationship between object and the property that is being stored remotely. this was happening because we'd assign the unique id per property and not per item so there'd be multiple db entries with the same 
remote identifier. using the object ID will fix this problem because it's still a unique ID and we're also now tying the id to the object itself instead of the property definition.