### PR TITLE
Fix code surrounding uploadDocument and deleteDocument methods

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,6 @@
+## 4.1.0
+* Resolve bug with calls to uploadDocument where s3 documents would be erroneously uploaded
+* Fix s3 rollbacks to delete the object via its versionId rather than marking it as deleted
 ## 4.0.0
 * Npm audit updated all modules
 * Updated Mongo and Knex modules to higher major versions, leading to breaking changes

--- a/components/persistor/lib/api.ts
+++ b/components/persistor/lib/api.ts
@@ -1187,7 +1187,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             savedObjects: {},
             touchObjects: {},
             deletedObjects: {},
-            remoteObjects: new Set(),
+            remoteObjects: new Map(),
             deleteQueries: {}
         };
     };
@@ -1199,7 +1199,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             savedObjects: {},
             touchObjects: {},
             deletedObjects: {},
-            remoteObjects: new Set(),
+            remoteObjects: new Map(),
             deleteQueries: {}
         };
 

--- a/components/persistor/lib/remote-doc/RemoteDocService.ts
+++ b/components/persistor/lib/remote-doc/RemoteDocService.ts
@@ -2,6 +2,11 @@ import { RemoteDocClient } from './remote-doc-types/index';
 import { LocalStorageDocClient } from './remote-doc-clients/LocalStorageDocClient';
 import { S3RemoteDocClient } from './remote-doc-clients/S3RemoteDocClient';
 
+export type UploadDocumentResponse = {
+    key: string,
+    versionId?: string
+};
+
 export class RemoteDocService {
     private remoteDocClient: RemoteDocClient;
 
@@ -14,16 +19,20 @@ export class RemoteDocService {
         return this;
     }
 
-    public async uploadDocument(base64: string, key: string, bucket: string) {
-        return this.remoteDocClient.uploadDocument(base64, key, bucket);
+    public async uploadDocument(base64: string, key: string, bucket: string): Promise<UploadDocumentResponse|any> {
+        const uploadDocumentResponse = await this.remoteDocClient.uploadDocument(base64, key, bucket);
+        return {
+            key,
+            versionId: (uploadDocumentResponse || {}).VersionId
+        };
     }
 
     public async downloadDocument(key: string, bucket: string) {
         return this.remoteDocClient.downloadDocument(key, bucket);
     }
 
-    public async deleteDocument(key: string, bucket: string) {
-        return this.remoteDocClient.deleteDocument(key, bucket);
+    public async deleteDocument(key: string, bucket: string, versionId?: string) {
+        return this.remoteDocClient.deleteDocument(key, bucket, versionId);
     }
 
     private static remoteDocClientFactory (remoteDocClient: string): RemoteDocClient {

--- a/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
@@ -46,7 +46,7 @@ export class S3RemoteDocClient implements RemoteDocClient {
      * @param {string} bucket - the name of the s3 bucket
      * @returns {Promise<S3.PutObjectOutput>} - standard aws result object following an s3 upload
      */
-    public async uploadDocument(s3ObjectToBeUploaded: string, key: string, bucket: string) {
+    public async uploadDocument(s3ObjectToBeUploaded: string, key: string, bucket: string): Promise<S3.PutObjectOutput> {
         const bucketParams: S3.PutObjectRequest = {
             Bucket: bucket,
             Key: key,
@@ -60,7 +60,7 @@ export class S3RemoteDocClient implements RemoteDocClient {
                 if (err) {
                     reject(err.message);
                 } else {
-                    resolve();
+                    resolve(data);
                 }
             });
         });
@@ -99,13 +99,18 @@ export class S3RemoteDocClient implements RemoteDocClient {
      *
      * @param {string} key - the unique identifier for this item within its s3 bucket
      * @param {string} bucket - the name of the s3 bucket
+     * @param {string} versionId? - the versionId for the item in the case the bucket is versioned
      * @returns {Promise<any>}
      */
-    public async deleteDocument(key: string, bucket: string) {
+    public async deleteDocument(key: string, bucket: string, versionId?: string) {
         const params: S3.DeleteObjectRequest = {
             Bucket: bucket,
             Key: key
         };
+
+        if (versionId) {
+            params.VersionId = versionId;
+        }
 
         const s3Conn = await this.getConnection(bucket);
 

--- a/components/persistor/lib/remote-doc/remote-doc-types/RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-types/RemoteDocClient.ts
@@ -1,5 +1,5 @@
 export interface RemoteDocClient {
     uploadDocument(base64: string, key: string, bucket: string);
     downloadDocument(key: string, bucket: string);
-    deleteDocument(key: string, bucket: string);
+    deleteDocument(key: string, bucket: string, versionId?: string);
 }

--- a/components/persistor/lib/types/PersistorTransaction.ts
+++ b/components/persistor/lib/types/PersistorTransaction.ts
@@ -4,6 +4,6 @@ export type PersistorTransaction = {
     savedObjects: object,
     touchObjects: object,
     deletedObjects: object,
-    remoteObjects: Set<string> // identifiers for objects not stored directly in our db
+    remoteObjects: Map<string, string> // identifiers for objects not stored directly in our db. key -> S3VersionId
     deleteQueries: {}
 };

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {

--- a/components/persistor/test/persist_banking_s3.js
+++ b/components/persistor/test/persist_banking_s3.js
@@ -1,0 +1,205 @@
+/*
+ * Banking example shows PersistObjectTemplate
+ * with remote object storage using S3RemoteDocClient
+ */
+
+const sinon = require('sinon');
+const S3RemoteDocClient = require('../dist/lib/remote-doc/remote-doc-clients/S3RemoteDocClient').S3RemoteDocClient;
+const expect = require('chai').expect;
+const AssertionError = require('chai').AssertionError;
+const ObjectTemplate = require('@havenlife/supertype').default;
+const PersistObjectTemplate = require('../dist/index.js')(ObjectTemplate, null, ObjectTemplate);
+const logLevel = process.env.logLevel || 'debug';
+
+PersistObjectTemplate.debugInfo = 'api;conflict;write;read;data';//'api;io';
+PersistObjectTemplate.debugInfo = 'conflict;data';//'api;io';
+PersistObjectTemplate.logger.setLevel(logLevel);
+
+const Customer = PersistObjectTemplate.create('Customer', {
+    init: function (bankingDocumentValue) {
+        this.bankingDocument = bankingDocumentValue;
+    },
+    bankingDocument: {
+        type: String,
+        isRemoteObject: true,
+        remoteKeyBase: 'test-remote-key',
+        value: null
+    }
+});
+
+const schema = {
+    Customer: {
+        documentOf: 'pg/customer'
+    }
+}
+
+function clearCollection(template) {
+    let collectionName = template.__collection__.match(/\//) ? template.__collection__ : 'mongo/' + template.__collection__;
+    if (collectionName.match(/pg\/(.*)/)) {
+        collectionName = RegExp.$1;
+        return PersistObjectTemplate.dropKnexTable(template)
+            .then(function () {
+                return PersistObjectTemplate.synchronizeKnexTableFromTemplate(template).then(function() {return 0});
+            });
+    } else
+        throw 'Invalid collection name ' + collectionName;
+}
+
+describe('Banking from pgsql Example persist_banking_s3', function () {
+    let knex;
+
+    afterEach(function() {
+        sinon.restore();
+    });
+
+    let noBankingDocumentCustomer;
+
+    before(async () => {
+        knex = require('knex')({
+            client: 'pg',
+            connection: {
+                host: process.env.dbPath,
+                database: process.env.dbName,
+                user: process.env.dbUser,
+                password: process.env.dbPassword,
+
+            }
+        });
+        PersistObjectTemplate.setRemoteDocConnection({
+            persistorBucketName: 'test-bucket-persistor',
+            persistorRemoteDocEnvironment: 'S3'
+        });
+        PersistObjectTemplate.setDB(knex, PersistObjectTemplate.DB_Knex,  'pg');
+        PersistObjectTemplate.setSchema(schema);
+        PersistObjectTemplate.performInjections(); // Normally done by getTemplates
+
+        this.timeout(4000);
+
+        const schemaTable = 'index_schema_history';
+        await knex.schema.dropTableIfExists(schemaTable)
+        const count = await clearCollection(Customer);
+        expect(count).to.equal(0);
+
+        noBankingDocumentCustomer = new Customer();
+
+        PersistObjectTemplate.begin();
+        noBankingDocumentCustomer.setDirty();
+        const result = await PersistObjectTemplate.end();
+        expect(result).to.equal(true);
+    });
+
+    context('when downloading an existing banking document', () => {
+        const bankingDocumentData = 'initial data';
+        let bankingDocumentCustomer;
+
+        beforeEach(async () => {
+            sinon.replace(S3RemoteDocClient.prototype, 'uploadDocument', () => (
+                Promise.resolve()
+            ));
+
+            bankingDocumentCustomer = new Customer(bankingDocumentData);
+            PersistObjectTemplate.begin();
+            bankingDocumentCustomer.setDirty();
+
+            const result = await PersistObjectTemplate.end();
+            expect(result).to.equal(true);
+        });
+
+        context('errors', () => {
+            const downloadDocumentError = new Error('failed to download document');
+
+            beforeEach(() => {
+                sinon.replace(S3RemoteDocClient.prototype, 'downloadDocument', () => (
+                    Promise.reject(downloadDocumentError)
+                ));
+            });
+
+            it('returns null for the remote field and logs error', async () => {
+                const fetchedBankDocCust = await Customer.getFromPersistWithId(bankingDocumentCustomer._id)
+                expect(fetchedBankDocCust.bankingDocument).to.eql(null);
+            });
+        });
+
+        context('succeeds', () => {
+            beforeEach(() => {
+                sinon.replace(S3RemoteDocClient.prototype, 'downloadDocument', () => (
+                    Promise.resolve(bankingDocumentData)
+                ));
+            });
+
+            it('should match the remote', async () => {
+                const fetchedBankDocCust = await Customer.getFromPersistWithId(bankingDocumentCustomer._id)
+                expect(fetchedBankDocCust.bankingDocument).to.eql(bankingDocumentData);
+            });
+        });
+    });
+
+    context('when uploading a banking document', () => {
+        let bankingDocumentStr = null;
+
+        beforeEach(() => {
+            sinon.replace(S3RemoteDocClient.prototype, 'downloadDocument', () => (
+                Promise.resolve(bankingDocumentStr)
+            ));
+        });
+
+        context('it succeeds', () => {
+            beforeEach(() => {
+                bankingDocumentStr = 'this should be stored remotely';
+                sinon.replace(S3RemoteDocClient.prototype, 'uploadDocument', () => (
+                    Promise.resolve()
+                ));
+            });
+
+            it('should save to remote store', async () => {
+                let fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id)
+
+                const txn = PersistObjectTemplate.begin();
+                fetchedNoBankDocCust.bankingDocument = bankingDocumentStr;
+                fetchedNoBankDocCust.setDirty();
+
+                await PersistObjectTemplate.end(txn);
+
+                fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id)
+                expect(fetchedNoBankDocCust.bankingDocument).to.eql(bankingDocumentStr);
+            });
+        });
+
+        context('it errors', () => {
+            let uploadError;
+            beforeEach(() => {
+                uploadError = new Error('Upload Failed');
+                sinon.replace(S3RemoteDocClient.prototype, 'uploadDocument', () => (
+                    Promise.reject(uploadError)
+                ));
+            });
+
+            it('should rollback transaction on failure to save to remote store', async () => {
+                let fetchedNoBankDocCust;
+
+                try {
+                    fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id)
+                    const txn = PersistObjectTemplate.begin();
+                    fetchedNoBankDocCust.bankingDocument = 'this should have rolled back';
+                    fetchedNoBankDocCust.setDirty();
+
+                    await PersistObjectTemplate.end(txn);
+                    expect.fail('Expected transaction to fail');
+                } catch (e) {
+                    if (e instanceof AssertionError) {
+                        throw e;
+                    }
+                    expect(e).to.eql(uploadError);
+
+                    fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id);
+                    expect(fetchedNoBankDocCust.bankingDocument).to.not.equal('this should have rolled back');
+                    expect(fetchedNoBankDocCust.bankingDocument).to.equal(bankingDocumentStr);
+                }
+            });
+        });
+    });
+
+    after('closes the database', function () {
+        return knex.destroy();
+    });
+});


### PR DESCRIPTION
The inspiration for these changes came once we attempted to start using these `RemoteDocService` functions with Amazon S3.

We found two issues:
1. when a series of database insert/updates failed, the corresponding remote uploads still occurred
2. when a rollback occurred, the remote uploads were not actually deleted. The loop iterating over all remote objects was not executing, and once we were able to make it execute the objects were just marked as deleted rather than being deleted. In a rollback scenario we want the objects to be completely deleted since they are not referenced in the database, leading to 'dangling objects'.