### PR TITLE
remove node warnings for legacy methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.10.0
+      - image: circleci/node:latest
         environment:
           port: 3001
           dbUser: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:8.10.0
         environment:
           port: 3001
           dbUser: postgres
@@ -12,7 +12,7 @@ jobs:
 
       - image: circleci/mongo:4.2.7
 
-      - image: circleci/postgres:9.6.7
+      - image: circleci/postgres:latest
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
       - image: circleci/mongo:latest
 
-      - image: circleci/postgres:latest
+      - image: circleci/postgres:9.6.7
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           mongoHost: localhost
           logLevel: info
 
-      - image: circleci/mongo:latest
+      - image: circleci/mongo:4.2.7
 
       - image: circleci/postgres:9.6.7
         environment:

--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,5 @@
+## 4.1.1
+* remove node warnings for legacy calls
 ## 4.1.0
 * Resolve bug with calls to uploadDocument where s3 documents would be erroneously uploaded
 * Fix s3 rollbacks to delete the object via its versionId rather than marking it as deleted

--- a/components/persistor/lib/api.ts
+++ b/components/persistor/lib/api.ts
@@ -162,8 +162,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
          * @legacy Use persistorFetchById instead
          */
         template.getFromPersistWithId = async function (id, cascade, isTransient, idMap, isRefresh, logger) {
-            process.emitWarning('getFromPersistWithId: Use persistorFetchById for alternative approaches', 'PERSISTOR_LEGACY');
-
             (logger || PersistObjectTemplate.logger).debug({
                 component: 'persistor', module: 'api', activity: 'getFromPersistWithId',
                 data: { template: template.__name__, id: id }
@@ -203,8 +201,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
          * @legacy in favor of persistorFetchByQuery
          */
         template.getFromPersistWithQuery = async function (query, cascade, start, limit, isTransient, idMap, options, logger) {
-            process.emitWarning('getFromPersistWithQuery: Use persistorFetchByQuery for alternative approaches', 'PERSISTOR_LEGACY');
-
             (logger || PersistObjectTemplate.logger).debug({
                 component: 'persistor', module: 'api', activity: 'getFromPersistWithQuery',
                 data: { template: template.__name__ }
@@ -239,8 +235,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
          * @legacy in favor of persitorDeleteByQuery
          */
         template.deleteFromPersistWithQuery = async function (query, txn, logger) {
-            process.emitWarning('deleteFromPersistWithQuery: Use persistorDeleteByQuery for alternative approaches', 'PERSISTOR_LEGACY');
-
             var dbType = PersistObjectTemplate.getDB(PersistObjectTemplate.getDBAlias(template.__collection__)).type;
             const time = getTime();
 
@@ -412,7 +406,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
          * @legacy in favor of persistorDeleteByQuery
          */
         template.deleteFromPersistWithId = async function (id, txn, logger) {
-            process.emitWarning('deleteFromPersistWithId: Use persistorDeleteByQuery for alternative approaches', 'PERSISTOR_LEGACY');
             const time = getTime();
 
             (logger || PersistObjectTemplate.logger).debug({
@@ -445,8 +438,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
          * @legacy in favor of persistorCountWithQuery
          */
         template.countFromPersistWithQuery = async function (query, logger) {
-            process.emitWarning('countFromPersistWithQuery: Use persistorCountByQuery for alternative approaches', 'PERSISTOR_LEGACY');
-
             const time = getTime();
 
             (logger || PersistObjectTemplate.logger).debug({
@@ -616,7 +607,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
         template.prototype.persistSave = // Legacy
             function (txn, logger) {
-                process.emitWarning('persistSave: Use persistorSave, cascadeSave (for multiple entities), or setDirty (for daemon applications) for alternative approaches', 'PERSISTOR_LEGACY');
                 const time = getTime();
 
                 var persistObjectTemplate = this.__objectTemplate__ || self;
@@ -655,7 +645,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
         template.prototype.persistTouch = // Legacy -- just use persistorSave
             async function (txn, logger) {
-                process.emitWarning('persistTouch: Use persistorSave for alternative approaches', 'PERSISTOR_LEGACY');
                 const time = getTime();
                 var persistObjectTemplate = this.__objectTemplate__ || self;
                 (logger || persistObjectTemplate.logger).debug({
@@ -683,8 +672,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
         //persistDelete is modified to support both legacy and V2, options this is passed for V2 as the first parameter.
         template.prototype.persistDelete = // Legacy
             async function (txn, logger) {
-                process.emitWarning('persistDelete', 'PERSISTOR_LEGACY');
-
                 const time = getTime();
 
                 var persistObjectTemplate = this.__objectTemplate__ || self;
@@ -993,8 +980,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
      * @returns {object} returns transaction object
      */
     PersistObjectTemplate.begin = function (notDefault) {
-        process.emitWarning('begin: Use beginTransaction for alternative approaches', 'PERSISTOR_LEGACY');
-
         var txn = { id: new Date().getTime(), dirtyObjects: {}, savedObjects: {}, touchObjects: {}, deletedObjects: {}};
         if (!notDefault) {
             this.currentTransaction = txn;
@@ -1004,8 +989,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
 
 
     PersistObjectTemplate.end = function (persistorTransaction, logger) {
-        process.emitWarning('end: Use commit for alternative approaches', 'PERSISTOR_LEGACY');
-
         persistorTransaction = persistorTransaction || this.currentTransaction;
         logger = logger || PersistObjectTemplate.logger;
         return PersistObjectTemplate.commit({ transaction: persistorTransaction, logger: logger });
@@ -1089,8 +1072,6 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
     };
 
     PersistObjectTemplate.saveAll = async function (txn, logger) {
-        process.emitWarning('saveAll: Use persistorSave for alternative approaches', 'PERSISTOR_LEGACY');
-
         var time = getTime();
         var promises = [];
         var somethingSaved = false;

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
excess logging is causing issues. also, directly using node's logging api takes away the control we want to pass to the consumer by allowing a logger to be in injected so let's revert this change until we can find an appropriate log level or other mechanism to log these.