### PR TITLE
Wrap file path logic in try catch

### DIFF
--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -26,9 +26,8 @@ function processFile(req, resp, next, downloads) {
 
     let form = new formidable.IncomingForm();
     form.uploadDir = downloads;
-
-    try {
-        form.parse(req, function ee(err, _fields, files) {
+    form.parse(req, function ee(err, _fields, files) {
+        try {
             if (err) {
                 logMessage(err);
             }
@@ -36,7 +35,7 @@ function processFile(req, resp, next, downloads) {
             let file = files.file.path;
             resp.writeHead(200, {'content-type': 'text/html'});
             logMessage(file);
-      
+        
             setTimeout(function yz() {
                 fs.unlink(file, function zy(err) {
                     if (err) {
@@ -56,9 +55,8 @@ function processFile(req, resp, next, downloads) {
             statsdUtils.computeTimingAndSend(
                 processFileTime,
                 'amorphic.webserver.process_file.response_time',
-                { result: 'success' });
-        });
-    } catch (error) {
+                { result: 'success' });   
+        } catch (error) {
             resp.writeHead(500, {'Content-Type': 'text/plain'});
             resp.end(error.toString());
             logMessage(err);
@@ -68,7 +66,8 @@ function processFile(req, resp, next, downloads) {
                 { result: 'Invalid request parameters' }
             );
             return;
-    }
+        }
+    });
 }
 
 module.exports = {

--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -32,8 +32,6 @@ function processFile(req, resp, next, downloads) {
             logMessage(err);
         }
 
-        resp.writeHead(200, {'content-type': 'text/html'});
-
         if (!files || !files.file) {
             resp.writeHead(400, {'Content-Type': 'text/plain'});
             resp.end(error.toString());
@@ -45,7 +43,9 @@ function processFile(req, resp, next, downloads) {
             );
             return;
         }
-        
+
+        resp.writeHead(200, {'content-type': 'text/html'});
+
         let file = files.file.path;
         logMessage(file);
 

--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -34,7 +34,7 @@ function processFile(req, resp, next, downloads) {
 
         if (!files || !files.file) {
             resp.writeHead(400, {'Content-Type': 'text/plain'});
-            resp.end(error.toString());
+            resp.end('Invalid request parameters');
             logMessage(err);
             statsdUtils.computeTimingAndSend(
                 processFileTime,

--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -27,46 +27,46 @@ function processFile(req, resp, next, downloads) {
     let form = new formidable.IncomingForm();
     form.uploadDir = downloads;
     form.parse(req, function ee(err, _fields, files) {
-        try {
-            if (err) {
-                logMessage(err);
-            }
+        if (err) {
+            logMessage(err);
+        }
 
-            let file = files.file.path;
-            resp.writeHead(200, {'content-type': 'text/html'});
-            logMessage(file);
-        
-            setTimeout(function yz() {
-                fs.unlink(file, function zy(err) {
-                    if (err) {
-                        logMessage(err);
-                    }
-                    else {
-                        logMessage(file + ' deleted');
-                    }
-                });
-            }, 60000);
-
-            let fileName = files.file.name;
-            req.session.file = file;
-            resp.end('<html><body><script>parent.amorphic.prepareFileUpload(\'package\');' +
-                'parent.amorphic.uploadFunction.call(null, "' +  fileName + '"' + ')</script></body></html>');
-
-            statsdUtils.computeTimingAndSend(
-                processFileTime,
-                'amorphic.webserver.process_file.response_time',
-                { result: 'success' });   
-        } catch (error) {
-            resp.writeHead(500, {'Content-Type': 'text/plain'});
+        if (!files || !files.file) {
+            resp.writeHead(400, {'Content-Type': 'text/plain'});
             resp.end(error.toString());
             logMessage(err);
             statsdUtils.computeTimingAndSend(
                 processFileTime,
                 'amorphic.webserver.process_file.response_time',
-                { result: 'Invalid request parameters' }
+                { result: 'Invalid request parameters, file or path params cannot be blank' }
             );
             return;
         }
+
+        let file = files.file.path;
+        resp.writeHead(200, {'content-type': 'text/html'});
+        logMessage(file);
+    
+        setTimeout(function yz() {
+            fs.unlink(file, function zy(err) {
+                if (err) {
+                    logMessage(err);
+                }
+                else {
+                    logMessage(file + ' deleted');
+                }
+            });
+        }, 60000);
+
+        let fileName = files.file.name;
+        req.session.file = file;
+        resp.end('<html><body><script>parent.amorphic.prepareFileUpload(\'package\');' +
+            'parent.amorphic.uploadFunction.call(null, "' +  fileName + '"' + ')</script></body></html>');
+
+        statsdUtils.computeTimingAndSend(
+            processFileTime,
+            'amorphic.webserver.process_file.response_time',
+            { result: 'success' });   
     });
 }
 

--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -26,10 +26,13 @@ function processFile(req, resp, next, downloads) {
 
     let form = new formidable.IncomingForm();
     form.uploadDir = downloads;
+
     form.parse(req, function ee(err, _fields, files) {
         if (err) {
             logMessage(err);
         }
+
+        resp.writeHead(200, {'content-type': 'text/html'});
 
         if (!files || !files.file) {
             resp.writeHead(400, {'Content-Type': 'text/plain'});
@@ -42,11 +45,10 @@ function processFile(req, resp, next, downloads) {
             );
             return;
         }
-
+        
         let file = files.file.path;
-        resp.writeHead(200, {'content-type': 'text/html'});
         logMessage(file);
-    
+
         setTimeout(function yz() {
             fs.unlink(file, function zy(err) {
                 if (err) {
@@ -66,7 +68,7 @@ function processFile(req, resp, next, downloads) {
         statsdUtils.computeTimingAndSend(
             processFileTime,
             'amorphic.webserver.process_file.response_time',
-            { result: 'success' });   
+            { result: 'success' });
     });
 }
 


### PR DESCRIPTION
Haven discovered that direct trigger of Post call for following url brings down the Haven application. In the last week of September this caused 14 Haven app crashes. 

the root cause is this line `let file = files.file.path `
This change is to wrap the line and surrounding lines into a try catch. 