### PR TITLE
Handle file request params null pointer issue for amorphic-6.0-protected branch - version 6.0.0

### DIFF
--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,3 +1,5 @@
+## 6.0.1
+* Handle null pointer exception when path or file params are undefined. 
 ## 6.0.0
 * Updated Knex and Mongo in persistor to latest major versions
 * Bringing in all of persistor versions greater than or equal to 4.0.0

--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -32,6 +32,18 @@ function processFile(req, resp, next, downloads) {
             logMessage(err);
         }
 
+        if (!files || !files.file) {
+            resp.writeHead(400, {'Content-Type': 'text/plain'});
+            resp.end('Invalid request parameters');
+            logMessage(err);
+            statsdUtils.computeTimingAndSend(
+                processFileTime,
+                'amorphic.webserver.process_file.response_time',
+                { result: 'Invalid request parameters, file or path params cannot be blank' }
+            );
+            return;
+        }
+
         resp.writeHead(200, {'content-type': 'text/html'});
 
         let file = files.file.path;

--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amorphic",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/components/amorphic/package.json
+++ b/components/amorphic/package.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/haven-life/amorphic",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"dependencies": {
 		"@havenlife/persistor": "4.x",
 		"@havenlife/semotus": "3.x",


### PR DESCRIPTION
the root cause is this line let file = files.file.path
This change is to handle files null pointer exceptions

This change updates version 6.0.0 of amorphic