### PR TITLE
Add filetype support in remote doc integration

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,5 @@
+## 5.2.0
+* adding content type property on the template to inform remote doc interactions
 ## 5.0.0
 * Persistor should set the version back to the original value when there is an error in the SQL.
 ## 4.4.0

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -148,7 +148,12 @@ module.exports = function (PersistObjectTemplate) {
             } else if (defineProperty.isRemoteObject && defineProperty.isRemoteObject === true) {
                 const uniqueIdentifier = obj._id;
 
+                // contents of the object itself
                 const remoteObject: string = obj[prop];
+
+                // MIME type of the object e.g. for a pdf, 'application/pdf'
+                // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+                const mimeType: string = obj[`${prop}_RemoteMIMEType`];
 
                 if (remoteObject && defineProperty.remoteKeyBase) {
                     remoteDocService = RemoteDocService.new(this.environment, this.remoteDocHostURL);
@@ -161,8 +166,21 @@ module.exports = function (PersistObjectTemplate) {
                     const bucket = this.bucketName;
 
                     try {
+                        (logger || this.logger).debug({
+                            component: 'persistor',
+                            module: 'update',
+                            activity: 'persistSaveKnex',
+                            data: {
+                                template: obj.__template__.__name__,
+                                message: 'we are uploading the document with params',
+                                documentBody: documentBody,
+                                objectKey: objectKey,
+                                bucket: bucket,
+                                mimeType: mimeType
+                            }
+                        });
                         // push function to upload the document to remote store
-                        remoteUpdateFns.push(() => remoteDocService.uploadDocument(documentBody, objectKey, bucket));
+                        remoteUpdateFns.push(() => remoteDocService.uploadDocument(documentBody, objectKey, bucket, mimeType));
 
                         // only place a reference to the remote object in the database itself - not the actual
                         // contents of the property.

--- a/components/persistor/lib/remote-doc/RemoteDocService.ts
+++ b/components/persistor/lib/remote-doc/RemoteDocService.ts
@@ -19,8 +19,8 @@ export class RemoteDocService {
         return this;
     }
 
-    public async uploadDocument(base64: string, key: string, bucket: string): Promise<UploadDocumentResponse|any> {
-        const uploadDocumentResponse = await this.remoteDocClient.uploadDocument(base64, key, bucket);
+    public async uploadDocument(base64: string, key: string, bucket: string, contentType: string): Promise<UploadDocumentResponse|any> {
+        const uploadDocumentResponse = await this.remoteDocClient.uploadDocument(base64, key, bucket, contentType);
         return {
             key,
             versionId: (uploadDocumentResponse || {}).VersionId

--- a/components/persistor/lib/remote-doc/remote-doc-clients/LocalStorageDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-clients/LocalStorageDocClient.ts
@@ -31,9 +31,12 @@ export class LocalStorageDocClient implements RemoteDocClient {
      * @param {string} obj
      * @param {string} key
      * @param {string} bucket
+     * @param {string} contentType
      * @returns {Promise<any>}
+     *
+     * @TODO add content type into local testing solution
      */
-    public async uploadDocument(obj: string, key: string, bucket: string) {
+    public async uploadDocument(obj: string, key: string, bucket: string, contentType: string) {
         return new Promise((resolve, reject) => {
             fs.writeFile(this.fileBaseDirectory + bucket + '_' +  key + '.txt', obj, (err: NodeJS.ErrnoException) => {
                 if(err) {

--- a/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
@@ -8,6 +8,7 @@ export class S3RemoteDocClient implements RemoteDocClient {
 
     constructor(remoteDocHost?: string) {
         this.S3Host = remoteDocHost || 'https://s3.amazonaws.com/';
+
     }
 
     /**
@@ -49,13 +50,17 @@ export class S3RemoteDocClient implements RemoteDocClient {
      * @param s3ObjectToBeUploaded - the specific item being uploaded to s3
      * @param {string} key - the unique identifier for this item within its s3 bucket
      * @param {string} bucket - the name of the s3 bucket
+     * @param {string} contentType - the mime type of the content being uploaded
      * @returns {Promise<S3.PutObjectOutput>} - standard aws result object following an s3 upload
      */
-    public async uploadDocument(s3ObjectToBeUploaded: string, key: string, bucket: string): Promise<S3.PutObjectOutput> {
+    public async uploadDocument(s3ObjectToBeUploaded: S3.Body, key: string, bucket: string, contentType?: string): Promise<S3.PutObjectOutput> {
+
+        console.warn("we are about to upload with params", key, bucket, contentType);
         const bucketParams: S3.PutObjectRequest = {
             Bucket: bucket,
             Key: key,
-            Body: s3ObjectToBeUploaded
+            Body: s3ObjectToBeUploaded,
+            ContentType: contentType ? contentType : 'application/octet-stream'
         };
 
         const s3Conn = await this.getConnection(bucket);
@@ -70,6 +75,7 @@ export class S3RemoteDocClient implements RemoteDocClient {
             });
         });
     };
+
 
     /**
      * download s3 object by key.

--- a/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
@@ -8,7 +8,6 @@ export class S3RemoteDocClient implements RemoteDocClient {
 
     constructor(remoteDocHost?: string) {
         this.S3Host = remoteDocHost || 'https://s3.amazonaws.com/';
-
     }
 
     /**
@@ -55,7 +54,6 @@ export class S3RemoteDocClient implements RemoteDocClient {
      */
     public async uploadDocument(s3ObjectToBeUploaded: S3.Body, key: string, bucket: string, contentType?: string): Promise<S3.PutObjectOutput> {
 
-        console.warn("we are about to upload with params", key, bucket, contentType);
         const bucketParams: S3.PutObjectRequest = {
             Bucket: bucket,
             Key: key,

--- a/components/persistor/lib/remote-doc/remote-doc-types/RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-types/RemoteDocClient.ts
@@ -1,5 +1,29 @@
+/**
+ * the contract that we're using to define any remote document store clients
+ */
 export interface RemoteDocClient {
-    uploadDocument(base64: string, key: string, bucket: string, contentType: string);
+    /**
+     *
+     * @param document - the payload of the object we're trying to save
+     * @param key - the unique key we're using to identify the document in the remote store
+     * @param bucket - the bucket that we're storing the document in
+     * @param contentType - the mime type of the object we're trying to store
+     */
+    uploadDocument(document: any, key: string, bucket: string, contentType: string);
+
+    /**
+     *
+     * @param key - the unique key we're using to identify the document in the remote store
+     * @param bucket - the bucket that we're storing the document in
+     */
     downloadDocument(key: string, bucket: string);
+
+    /**
+     *
+     * @param key - the unique key we're using to identify the document in the remote store
+     * @param bucket - the bucket that we're storing the document in
+     * @param versionId - optional version, used in the case that we don't want to delete the object entirely
+     * but rather just go back a version
+     */
     deleteDocument(key: string, bucket: string, versionId?: string);
 }

--- a/components/persistor/lib/remote-doc/remote-doc-types/RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-types/RemoteDocClient.ts
@@ -1,5 +1,5 @@
 export interface RemoteDocClient {
-    uploadDocument(base64: string, key: string, bucket: string);
+    uploadDocument(base64: string, key: string, bucket: string, contentType: string);
     downloadDocument(key: string, bucket: string);
     deleteDocument(key: string, bucket: string, versionId?: string);
 }

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -383,11 +383,6 @@
             "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
             "dev": true
         },
-        "@tokenizer/token": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-            "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
-        },
         "@types/bluebird": {
             "version": "3.5.20",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
@@ -406,11 +401,6 @@
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
-        "@types/debug": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
-        },
         "@types/mocha": {
             "version": "2.2.48",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -420,22 +410,14 @@
         "@types/node": {
             "version": "13.13.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.1.tgz",
-            "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ=="
+            "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ==",
+            "dev": true
         },
         "@types/q": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
             "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
             "dev": true
-        },
-        "@types/readable-stream": {
-            "version": "2.3.9",
-            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.9.tgz",
-            "integrity": "sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==",
-            "requires": {
-                "@types/node": "*",
-                "safe-buffer": "*"
-            }
         },
         "@types/reflect-metadata": {
             "version": "0.1.0",
@@ -1679,17 +1661,6 @@
                 "object-assign": "^4.0.1"
             }
         },
-        "file-type": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.2.0.tgz",
-            "integrity": "sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==",
-            "requires": {
-                "readable-web-to-node-stream": "^3.0.0",
-                "strtok3": "^6.0.3",
-                "token-types": "^2.0.0",
-                "typedarray-to-buffer": "^3.1.5"
-            }
-        },
         "fill-range": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2348,7 +2319,8 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
         },
         "is-unc-path": {
             "version": "1.0.0",
@@ -3548,11 +3520,6 @@
                 }
             }
         },
-        "peek-readable": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.3.tgz",
-            "integrity": "sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg=="
-        },
         "pg": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
@@ -3728,40 +3695,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
                     "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-                }
-            }
-        },
-        "readable-web-to-node-stream": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz",
-            "integrity": "sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==",
-            "requires": {
-                "@types/readable-stream": "^2.3.9",
-                "readable-stream": "^3.6.0"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
                 }
             }
         },
@@ -4390,16 +4323,6 @@
             "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
             "dev": true
         },
-        "strtok3": {
-            "version": "6.0.8",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.8.tgz",
-            "integrity": "sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==",
-            "requires": {
-                "@tokenizer/token": "^0.1.1",
-                "@types/debug": "^4.1.5",
-                "peek-readable": "^3.1.3"
-            }
-        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -4545,22 +4468,6 @@
                 "repeat-string": "^1.6.1"
             }
         },
-        "token-types": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
-            "integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
-            "requires": {
-                "@tokenizer/token": "^0.1.1",
-                "ieee754": "^1.2.1"
-            },
-            "dependencies": {
-                "ieee754": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-                }
-            }
-        },
         "ts-node": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
@@ -4644,6 +4551,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "5.0.0",
+    "version": "5.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -383,6 +383,11 @@
             "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
             "dev": true
         },
+        "@tokenizer/token": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+            "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+        },
         "@types/bluebird": {
             "version": "3.5.20",
             "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
@@ -401,6 +406,11 @@
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
+        "@types/debug": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+            "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+        },
         "@types/mocha": {
             "version": "2.2.48",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -410,14 +420,22 @@
         "@types/node": {
             "version": "13.13.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.1.tgz",
-            "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ==",
-            "dev": true
+            "integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ=="
         },
         "@types/q": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
             "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
             "dev": true
+        },
+        "@types/readable-stream": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.9.tgz",
+            "integrity": "sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==",
+            "requires": {
+                "@types/node": "*",
+                "safe-buffer": "*"
+            }
         },
         "@types/reflect-metadata": {
             "version": "0.1.0",
@@ -1661,6 +1679,17 @@
                 "object-assign": "^4.0.1"
             }
         },
+        "file-type": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.2.0.tgz",
+            "integrity": "sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==",
+            "requires": {
+                "readable-web-to-node-stream": "^3.0.0",
+                "strtok3": "^6.0.3",
+                "token-types": "^2.0.0",
+                "typedarray-to-buffer": "^3.1.5"
+            }
+        },
         "fill-range": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2319,8 +2348,7 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is-unc-path": {
             "version": "1.0.0",
@@ -3520,6 +3548,11 @@
                 }
             }
         },
+        "peek-readable": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.3.tgz",
+            "integrity": "sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg=="
+        },
         "pg": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
@@ -3695,6 +3728,40 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
                     "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+                }
+            }
+        },
+        "readable-web-to-node-stream": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz",
+            "integrity": "sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==",
+            "requires": {
+                "@types/readable-stream": "^2.3.9",
+                "readable-stream": "^3.6.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
                 }
             }
         },
@@ -4323,6 +4390,16 @@
             "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
             "dev": true
         },
+        "strtok3": {
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.8.tgz",
+            "integrity": "sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==",
+            "requires": {
+                "@tokenizer/token": "^0.1.1",
+                "@types/debug": "^4.1.5",
+                "peek-readable": "^3.1.3"
+            }
+        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -4468,6 +4545,22 @@
                 "repeat-string": "^1.6.1"
             }
         },
+        "token-types": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
+            "integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
+            "requires": {
+                "@tokenizer/token": "^0.1.1",
+                "ieee754": "^1.2.1"
+            },
+            "dependencies": {
+                "ieee754": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+                }
+            }
+        },
         "ts-node": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
@@ -4551,7 +4644,6 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "5.0.0",
+    "version": "5.2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {
@@ -14,7 +14,8 @@
         "q": "1.x",
         "tv4": "^1.2.7",
         "underscore": "1.x",
-        "uuid": "3.3.3"
+        "uuid": "3.3.3",
+        "file-type": "16.2.0"
     },
     "peerDependencies": {
         "@havenlife/supertype": "3.x"

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -14,8 +14,7 @@
         "q": "1.x",
         "tv4": "^1.2.7",
         "underscore": "1.x",
-        "uuid": "3.3.3",
-        "file-type": "16.2.0"
+        "uuid": "3.3.3"
     },
     "peerDependencies": {
         "@havenlife/supertype": "3.x"

--- a/components/persistor/test/persist_banking_s3.js
+++ b/components/persistor/test/persist_banking_s3.js
@@ -8,11 +8,13 @@ const expect = require('chai').expect;
 const AssertionError = require('chai').AssertionError;
 const ObjectTemplate = require('@havenlife/supertype').default;
 const PersistObjectTemplate = require('../dist/index.js')(ObjectTemplate, null, ObjectTemplate);
-const logLevel = process.env.logLevel || 'debug';
+const logLevel = 'debug';
 
 PersistObjectTemplate.debugInfo = 'api;conflict;write;read;data';//'api;io';
 PersistObjectTemplate.debugInfo = 'conflict;data';//'api;io';
 PersistObjectTemplate.logger.setLevel(logLevel);
+
+const sandbox = sinon.createSandbox();
 
 const Customer = PersistObjectTemplate.create('Customer', {
     init: function (bankingDocumentValue) {
@@ -23,6 +25,10 @@ const Customer = PersistObjectTemplate.create('Customer', {
         isRemoteObject: true,
         remoteKeyBase: 'test-remote-key',
         value: null
+    },
+    bankingDocument_RemoteMIMEType: {
+        type: String,
+        value: 'application/pdf'
     }
 });
 
@@ -123,7 +129,7 @@ describe('Banking from pgsql Example persist_banking_s3', function () {
             });
 
             it('returns null for the remote field and logs error', async () => {
-                const fetchedBankDocCust = await Customer.getFromPersistWithId(bankingDocumentCustomer._id)
+                const fetchedBankDocCust = await Customer.getFromPersistWithId(bankingDocumentCustomer._id);
                 expect(fetchedBankDocCust.bankingDocument).to.eql(null);
             });
         });
@@ -136,7 +142,7 @@ describe('Banking from pgsql Example persist_banking_s3', function () {
             });
 
             it('should match the remote', async () => {
-                const fetchedBankDocCust = await Customer.getFromPersistWithId(bankingDocumentCustomer._id)
+                const fetchedBankDocCust = await Customer.getFromPersistWithId(bankingDocumentCustomer._id);
                 expect(fetchedBankDocCust.bankingDocument).to.eql(bankingDocumentData);
             });
         });
@@ -157,10 +163,16 @@ describe('Banking from pgsql Example persist_banking_s3', function () {
                 sinon.replace(S3RemoteDocClient.prototype, 'uploadDocument', () => (
                     Promise.resolve()
                 ));
+
+                sandbox.spy(S3RemoteDocClient.prototype, 'uploadDocument');
             });
 
-            it('should save to remote store', async () => {
-                let fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id)
+            afterEach(() => {
+                sandbox.restore();
+            });
+
+            it('should send with correct mime type', async () => {
+                let fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id);
 
                 const txn = PersistObjectTemplate.begin();
                 fetchedNoBankDocCust.bankingDocument = bankingDocumentStr;
@@ -168,7 +180,22 @@ describe('Banking from pgsql Example persist_banking_s3', function () {
 
                 await PersistObjectTemplate.end(txn);
 
-                fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id)
+                fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id);
+                expect(S3RemoteDocClient.prototype.uploadDocument.calledOnce).to.eql(true);
+                expect(S3RemoteDocClient.prototype.uploadDocument.getCall(0).args.length).to.eql(4);
+                expect(S3RemoteDocClient.prototype.uploadDocument.getCall(0).args[3]).to.eql('application/pdf');
+            });
+
+            it('should save to remote store', async () => {
+                let fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id);
+
+                const txn = PersistObjectTemplate.begin();
+                fetchedNoBankDocCust.bankingDocument = bankingDocumentStr;
+                fetchedNoBankDocCust.setDirty();
+
+                await PersistObjectTemplate.end(txn);
+
+                fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id);
                 expect(fetchedNoBankDocCust.bankingDocument).to.eql(bankingDocumentStr);
             });
         });
@@ -186,7 +213,7 @@ describe('Banking from pgsql Example persist_banking_s3', function () {
                 let fetchedNoBankDocCust;
 
                 try {
-                    fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id)
+                    fetchedNoBankDocCust = await Customer.getFromPersistWithId(noBankingDocumentCustomer._id);
                     const txn = PersistObjectTemplate.begin();
                     fetchedNoBankDocCust.bankingDocument = 'this should have rolled back';
                     fetchedNoBankDocCust.setDirty();

--- a/components/persistor/test/persist_banking_s3.js
+++ b/components/persistor/test/persist_banking_s3.js
@@ -8,7 +8,7 @@ const expect = require('chai').expect;
 const AssertionError = require('chai').AssertionError;
 const ObjectTemplate = require('@havenlife/supertype').default;
 const PersistObjectTemplate = require('../dist/index.js')(ObjectTemplate, null, ObjectTemplate);
-const logLevel = 'debug';
+const logLevel = process.env.logLevel || 'debug';
 
 PersistObjectTemplate.debugInfo = 'api;conflict;write;read;data';//'api;io';
 PersistObjectTemplate.debugInfo = 'conflict;data';//'api;io';


### PR DESCRIPTION
Add the ability to control the MIME type of data being uploaded to remote doc stores. 

Example - remote doc property called 'idDoc' on object Person. you would store the PDF in the remote doc property as usual - then additionally store a string of the MIME type as property `idDoc_RemoteMIMEType`. The pattern being original prop name + static string "_RemoteMIMEType". This is the place the persistor will expect the meta type to live - otherwise defaulting to the generic `application/octet-stream` type.