### PR TITLE
Fix Form Parsing Error State

### DIFF
--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,5 +1,7 @@
 ## 8.0.0
 * Updating for injectable config, and config is now in supertype
+## 7.1.2
+* ensure we don't call logic to send response twice on form parsing error condition 
 ## 7.1.1
 * Added bug handling and better errors for uploads
 ## 7.1.0

--- a/components/amorphic/lib/routes/processFile.js
+++ b/components/amorphic/lib/routes/processFile.js
@@ -47,10 +47,8 @@ function processFile(req, resp, next, downloads) {
         // there was an error attempting to parse the form. log it out, and send back an error response.
         if (err) {
             logMessage(err);
-
             resp.writeHead(500, {'Content-Type': 'text/plain'});
             resp.end('unable to parse form');
-            logMessage(err);
             statsdUtils.computeTimingAndSend(
                 processFileTime,
                 'amorphic.webserver.process_file.response_time',

--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amorphic",
-	"version": "7.1.1",
+	"version": "7.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/components/amorphic/package.json
+++ b/components/amorphic/package.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/haven-life/amorphic",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"version": "7.1.1",
+	"version": "7.1.2",
 	"dependencies": {
 		"@havenlife/persistor": "5.x",
 		"@havenlife/semotus": "4.x",


### PR DESCRIPTION
In a form parsing error state, the response was being sent back twice. add a boolean switch to ensure we're not doing this anymore.