### PR TITLE
Don't alter the remote object before sending back

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,5 @@
+## 5.2.1
+* return the remote document content in its original format
 ## 5.2.0
 * adding content type property on the template to inform remote doc interactions
 ## 5.1.0

--- a/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
+++ b/components/persistor/lib/remote-doc/remote-doc-clients/S3RemoteDocClient.ts
@@ -95,7 +95,7 @@ export class S3RemoteDocClient implements RemoteDocClient {
                 if (err) {
                     reject(err);
                 } else {
-                    resolve(data && data.Body ? data.Body.toString() : data.Body);
+                    resolve(data ? data.Body : undefined);
                 }
             });
         });

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@havenlife/persistor",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@havenlife/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
When we opened up the possibility for consumers to store other doc types aside from strings, we didn't remove the stringification on the download.

Return the body as-is so the consumer can decide how to parse it.