### PR TITLE
HL-000: add persistorIsFetched function

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,5 @@
+## 6.2.0
+* Added "persistorIsFetched" function
 ## 6.1.0
 * Including changes from persistor@5.5.2 to master
 

--- a/components/persistor/lib/api.ts
+++ b/components/persistor/lib/api.ts
@@ -306,7 +306,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             let deleteQuery = dbType == PersistObjectTemplate.DB_Mongo ?
                 PersistObjectTemplate.deleteFromPersistWithMongoQuery(template, query, options.logger) :
                 PersistObjectTemplate.deleteFromKnexByQuery(template, query, options.transaction, options.logger);
-            
+
             const name = 'persistorDeleteByQuery';
             return deleteQuery
                 .then(result => {
@@ -813,6 +813,14 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
                 });
         };
 
+        template.prototype.persistorIsFetched = function (prop: string) {
+            const persistorPropertyName = prop + 'Persistor';
+            if (this.hasOwnProperty(persistorPropertyName)) {
+                return this[persistorPropertyName].isFetched;
+            }
+            throw new Error('Unable to find Persistor property for ' + prop);
+        };
+
         template.prototype.persistorFetchReferences = template.prototype.fetchReferences = async function (options) {
             var persistObjectTemplate = this.__objectTemplate__ || self;
             persistObjectTemplate._validateParams(options, 'fetchSchema', this.__template__);
@@ -919,7 +927,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             configurable: true
         })
 
-        
+
         Object.defineProperty(template.prototype, 'objectTemplateName', {
             get: function () {
                 return (this.constructor && this.constructor.name) || template.__name__;
@@ -938,7 +946,7 @@ module.exports = function (PersistObjectTemplate, baseClassForPersist) {
             if (dbType == PersistObjectTemplate.DB_Mongo) {
                 throw new Error('Not supported this functionality for MongoDb.');
             }
-                
+
             return persistObjectTemplate.getInsertScript(this);
         };
 

--- a/components/persistor/lib/persistable.ts
+++ b/components/persistor/lib/persistable.ts
@@ -6,7 +6,7 @@ export class Persistor extends SupertypeSession {
     /**
      * @TODO: was typed `Persistor` but that's weird? doesn't work need to figure out what's going on.
      */
-    static create(): any | undefined {return undefined}; 
+    static create(): any | undefined {return undefined};
     beginDefaultTransaction() : any {}
 
     /**
@@ -186,6 +186,11 @@ export function Persistable<BC extends Constructable<{}>>(Base: BC) {
         persistorIsStale () : any {}
 
         /**
+         * Checks to see if the object has been fetched
+         */
+         persistorIsFetched(prop): any {};
+
+        /**
          * Can generate object id even before saving the record to the database
          *
          * @returns the string id
@@ -194,10 +199,10 @@ export function Persistable<BC extends Constructable<{}>>(Base: BC) {
 
         getInsertScript() : any {};
 
-        
+
         objectId : string ;
         objectTemplateName : string ;
-        
+
         _id: string;
         __version__: number;
         amorphic : Persistor;
@@ -233,7 +238,7 @@ export function Persistable<BC extends Constructable<{}>>(Base: BC) {
          * @async
          */
         static getFromPersistWithQuery(query, cascade?, start?, limit?, isTransient?, idMap?, options?, logger?) : any {}
-        
+
         /**
          * Delete objects given a json query
          *

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@haventech/persistor",
-    "version": "6.1.0",
+    "version": "6.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@haventech/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "6.1.0",
+    "version": "6.2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
Adding persistorIsFetched function to allow a simple check to determine whether or not a `.fetch` call needs to be made. Usage example would be:

```
const fetchSpec = { points: true };
if (!policy.persistorIsFetched('points')) {
    await policy.fetch(fetchSpec);
}
```