### PR TITLE
catch index errors

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,5 +1,9 @@
 ## 6.3.0
 * Catch cases where index is not generated
+* This MR is a short-term fix to address an issue of index errors that is causing startup to hang.
+* A catch all was added to catch and log any index errors and allowing rest of the logic to continue.
+* A more permanent fix is in works and will be addressed in couple of months.
+
 ## 6.2.0
 * Added "persistorIsFetched" function
 ## 6.1.0

--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,5 @@
+## 6.3.0
+* Catch cases where index is not generated
 ## 6.2.0
 * Added "persistorIsFetched" function
 ## 6.1.0

--- a/components/persistor/lib/knex/db.ts
+++ b/components/persistor/lib/knex/db.ts
@@ -825,6 +825,9 @@ module.exports = function (PersistObjectTemplate) {
                     syncIndexesForHierarchy('add', dbChanges, table);
                     syncIndexesForHierarchy('change', dbChanges, table);
                 }).catch(function (error) {
+                    if (error.message === 'index type can be only "unique" or "index"') {
+                        throw error;
+                    }
                     const logger = PersistObjectTemplate && PersistObjectTemplate.logger;
                     if (logger) {
                         logger.warn({

--- a/components/persistor/lib/knex/db.ts
+++ b/components/persistor/lib/knex/db.ts
@@ -824,8 +824,19 @@ module.exports = function (PersistObjectTemplate) {
                     syncIndexesForHierarchy('delete', dbChanges, table);
                     syncIndexesForHierarchy('add', dbChanges, table);
                     syncIndexesForHierarchy('change', dbChanges, table);
-                })
-            })
+                }).catch(function (error) {
+                    const logger = PersistObjectTemplate && PersistObjectTemplate.logger;
+                    if (logger) {
+                        logger.warn({
+                            component: 'persistor',
+                            dbChanges: dbChanges,
+                            module: 'db',
+                            activity: 'synchronizeIndexes',
+                            error: error
+                        }, 'Unable to update index');
+                    }
+                });
+            });       
         };
 
         var isSchemaChanged = function(object) {

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@haventech/persistor",
-    "version": "6.2.0",
+    "version": "6.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@haventech/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "6.2.0",
+    "version": "6.3.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {

--- a/components/persistor/test/persist_schema_updates.js
+++ b/components/persistor/test/persist_schema_updates.js
@@ -299,8 +299,7 @@ describe('schema update checks', function () {
         schema.newTable.indexes = (JSON.parse('[{"name": "scd_index","def": {"columns": ["id"],"type": "primary"}}]'));
 
         PersistObjectTemplate._verifySchema();
-        PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.not.contain('NewTable');
-        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.equal(true);
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.be.rejectedWith(Error, 'index type can be only "unique" or "index"');
     });
 
     it('add a new table definition to the schema and try to synchronize', function () {

--- a/components/persistor/test/persist_schema_updates.js
+++ b/components/persistor/test/persist_schema_updates.js
@@ -299,7 +299,8 @@ describe('schema update checks', function () {
         schema.newTable.indexes = (JSON.parse('[{"name": "scd_index","def": {"columns": ["id"],"type": "primary"}}]'));
 
         PersistObjectTemplate._verifySchema();
-        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.be.rejectedWith(Error, 'index type can be only "unique" or "index"');
+        PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.not.contain('NewTable');
+        return PersistObjectTemplate.synchronizeKnexTableFromTemplate(newTable).should.eventually.equal(true);
     });
 
     it('add a new table definition to the schema and try to synchronize', function () {


### PR DESCRIPTION
This MR is a short-term fix to address an issue of index errors that is causing startup to hang. 
A catch all was added to catch and log any index errors and allowing rest of the logic to continue. 
A more permanent fix is in works and will be addressed in couple of months.