### PR TITLE
Restrict loggingLevel passing to backend to log functions.

### DIFF
--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,3 +1,5 @@
+## 11.0.1
+* Restrict loggingLevel passing to backend to log functions.
 ## 11.0.0
 * BREAKING CHANGES: 
     With this upgrade we have changed the way logger is used by amorphic. In the past, clients passed

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -8,6 +8,8 @@ let url = require('url');
 let persistor = require('@haventech/persistor');
 let semotus = require('@haventech/semotus');
 
+const validLoggingLevel = new Set(['error', 'warn', 'info', 'debug']);
+
 /**
  * Purpose unknown
  *
@@ -20,7 +22,6 @@ function processLoggingMessage(req, res) {
 	let session = req.session;
 	let message = req.body;
 
-	const validLoggingLevel = new Set(['error', 'warn', 'info', 'debug']);
 	if(!validLoggingLevel.has(message.loggingLevel)) {
 		throw new Error(`Unsupported loggingLevel ${message.loggingLevel}`);
 	}

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -49,7 +49,6 @@ function processLoggingMessage(req, res) {
 	});
 
 	message.loggingData.from = 'browser';
-
 	persistableSemotableTemplate.logger[message.loggingLevel](message.loggingData);
 	res.writeHead(200, { 'Content-Type': 'text/plain' });
 	res.end('');

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -20,6 +20,11 @@ function processLoggingMessage(req, res) {
 	let session = req.session;
 	let message = req.body;
 
+	const validLoggingLevel = ['error', 'warn', 'info', 'debug'];
+	if(validLoggingLevel.indexOf(message.loggingLevel) === -1) {
+		throw new Error(`Unsupported loggingLevel ${message.loggingLevel}`);
+	}
+
 	let persistableSemotableTemplate = persistor(null, null, semotus);
 
 	if (!session.semotus) {
@@ -44,6 +49,7 @@ function processLoggingMessage(req, res) {
 	});
 
 	message.loggingData.from = 'browser';
+
 	persistableSemotableTemplate.logger[message.loggingLevel](message.loggingData);
 	res.writeHead(200, { 'Content-Type': 'text/plain' });
 	res.end('');

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -20,8 +20,8 @@ function processLoggingMessage(req, res) {
 	let session = req.session;
 	let message = req.body;
 
-	const validLoggingLevel = ['error', 'warn', 'info', 'debug'];
-	if(validLoggingLevel.indexOf(message.loggingLevel) === -1) {
+	const validLoggingLevel = new Set(['error', 'warn', 'info', 'debug']);
+	if(!validLoggingLevel.has(message.loggingLevel)) {
 		throw new Error(`Unsupported loggingLevel ${message.loggingLevel}`);
 	}
 

--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@haventech/amorphic",
-	"version": "11.0.0",
+	"version": "11.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/components/amorphic/package.json
+++ b/components/amorphic/package.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/haven-life/amorphic",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"version": "11.0.0",
+	"version": "11.0.1",
 	"dependencies": {
 		"@haventech/persistor": "9.x",
 		"@haventech/semotus": "7.x",

--- a/components/persistor/test/persist_newapi_tests.js
+++ b/components/persistor/test/persist_newapi_tests.js
@@ -17,7 +17,7 @@ var Phone, Address, Employee, empId, addressId, phoneId, Role;
 var PersistObjectTemplate, ObjectTemplate;
 
 describe('persist newapi tests', function () {
-    // this.timeout(5000);
+    this.timeout(5000);
     before('drop schema table once per test suit', function() {
         knex = knexInit({
             client: 'pg',


### PR DESCRIPTION
validate that the loggingLevel passed from browser must in one of `['error', 'warn', 'info', 'debug']`.