### PR TITLE
Restrict loggingLevel passing to backend to log functions.

### DIFF
--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,3 +1,5 @@
+## 11.0.1
+* Restrict loggingLevel passing to backend to log functions.
 ## 11.0.0
 * BREAKING CHANGES: 
     With this upgrade we have changed the way logger is used by amorphic. In the past, clients passed

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -8,7 +8,7 @@ let url = require('url');
 let persistor = require('@haventech/persistor');
 let semotus = require('@haventech/semotus');
 
-const validLoggingLevel = new Set(['error', 'warn', 'info', 'debug']);
+const validLoggingLevel = new Set(['error', 'warn', 'info', 'debug', 'trace', 'fatal']);
 
 /**
  * Purpose unknown

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -23,7 +23,9 @@ function processLoggingMessage(req, res) {
 	let message = req.body;
 
 	if(!validLoggingLevel.has(message.loggingLevel)) {
-		throw new Error(`Unsupported loggingLevel ${message.loggingLevel}`);
+		res.writeHead(400, {'Content-Type': 'text/plain'});
+		res.end(`Error: Unsupported loggingLevel ${message.loggingLevel}`);
+		return;
 	}
 
 	let persistableSemotableTemplate = persistor(null, null, semotus);

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -25,6 +25,7 @@ function processLoggingMessage(req, res) {
 	if(!validLoggingLevel.has(message.loggingLevel)) {
 		res.writeHead(400, {'Content-Type': 'text/plain'});
 		res.end(`Error: Unsupported loggingLevel ${message.loggingLevel}`);
+
 		return;
 	}
 

--- a/components/amorphic/lib/routes/processLoggingMessage.js
+++ b/components/amorphic/lib/routes/processLoggingMessage.js
@@ -8,6 +8,8 @@ let url = require('url');
 let persistor = require('@haventech/persistor');
 let semotus = require('@haventech/semotus');
 
+const validLoggingLevel = new Set(['error', 'warn', 'info', 'debug']);
+
 /**
  * Purpose unknown
  *
@@ -19,6 +21,10 @@ function processLoggingMessage(req, res) {
 	let path = url.parse(req.originalUrl, true).query.path;
 	let session = req.session;
 	let message = req.body;
+
+	if(!validLoggingLevel.has(message.loggingLevel)) {
+		throw new Error(`Unsupported loggingLevel ${message.loggingLevel}`);
+	}
 
 	let persistableSemotableTemplate = persistor(null, null, semotus);
 

--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@haventech/amorphic",
-	"version": "11.0.0",
+	"version": "11.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/components/amorphic/package.json
+++ b/components/amorphic/package.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/haven-life/amorphic",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"version": "11.0.0",
+	"version": "11.0.1",
 	"dependencies": {
 		"@haventech/persistor": "9.x",
 		"@haventech/semotus": "7.x",

--- a/components/amorphic/test/postgres/amorphic.js
+++ b/components/amorphic/test/postgres/amorphic.js
@@ -826,7 +826,7 @@ describe('processLoggingMessage', function() {
     after(afterEachDescribe);
 
     afterEach(function() {
-        sinon.restore();
+        amorphic._post.restore();
     });
 
     it('should post a message to the server of type "logging"', function() {


### PR DESCRIPTION
validate that the loggingLevel passed from browser must in one of `['error', 'warn', 'info', 'debug', 'trace', 'fatal']`.