### PR TITLE
Add config to override is remote object property

### DIFF
--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,6 +1,10 @@
 ## 9.4.0
 * Adding a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject` property on individual records, if they are set to false.
-* This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true you may override the behavior and allow for docs to be saved in a remote s3 bucket. For more information refer to the readme.
+* This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true you may override the behavior and allow for docs to be saved in a remote s3 bucket. 
+CAUTION: Setting this flag to `true`, on client side config, can cause all `isRemoteObject: false` properties set across the app (include properties set on modules if any) to be `true`. 
+So due diligence must be done enabling this flag on client side and any time `isRemoteObject` is set to false and also checks should be made to ensure if a module introduces new properties with `isRemoteObject: false`.
+For more information and details of the behavior, refer to the readme.
+
 ## 9.3.0
 * defining schema type in persistor
 ## 9.2.0

--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,6 +1,6 @@
 ## 10.0.0
-* Adding a config `enableIsRemoteObjectFeature` as a required config, to allow `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to true and client apps can safely upgrade to these modules without the requirement to also start using remoteStorage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to true in their respective config file(s). <br>
-**CAUTION:** This is an all or nothing flag. Once set to true the `isRemoteObject` behavior defined on individual properties will be enabled in all places. 
+* Adding a config `enableIsRemoteObjectFeature` as a required config, to allow `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to `true` and client apps can safely upgrade to these modules without the requirement to also start using remote storage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to `true` in their respective config file(s). <br>
+**CAUTION:** This is an all or nothing flag. Once `enableIsRemoteObjectFeature` is set to `true` the `isRemoteObject` behavior defined on individual properties will be enabled in all places. 
 For more information and details of the behavior, please refer to the README.
 
 ## 9.3.0

--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,9 +1,7 @@
-## 9.4.0
-* Adding a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject` property on individual records, if they are set to false.
-* This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true you may override the behavior and allow for docs to be saved in a remote s3 bucket. 
-**CAUTION:** Setting this flag to `true`, on client side config, can cause all `isRemoteObject: false` properties set across the app (include properties set on modules if any) to be `true`. 
-So due diligence must be done before enabling this flag on client side. You should also be mindful of any future cases when `isRemoteObject: false` could be is set on other future module releases.
-For more information and details of the behavior, refer to the README.
+## 10.0.0
+* Adding a config `enableIsRemoteObjectFeature` as a required config, to allow `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to true and client apps can safely upgrade to these modules without the requirement to also start using remoteStorage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to true in their respective config file(s). <br>
+**CAUTION:** This is an all or nothing flag. Once set to true the `isRemoteObject` behavior defined on individual properties will be enabled in all places. 
+For more information and details of the behavior, please refer to the README.
 
 ## 9.3.0
 * defining schema type in persistor

--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,3 +1,6 @@
+## 9.4.0
+* Adding a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject` property on individual records, if they are set to false.
+* This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true you may override the behavior and allow for docs to be saved in a remote s3 bucket. For more information refer to the readme.
 ## 9.3.0
 * defining schema type in persistor
 ## 9.2.0

--- a/components/persistor/HISTORY.md
+++ b/components/persistor/HISTORY.md
@@ -1,9 +1,9 @@
 ## 9.4.0
 * Adding a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject` property on individual records, if they are set to false.
 * This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true you may override the behavior and allow for docs to be saved in a remote s3 bucket. 
-CAUTION: Setting this flag to `true`, on client side config, can cause all `isRemoteObject: false` properties set across the app (include properties set on modules if any) to be `true`. 
-So due diligence must be done enabling this flag on client side and any time `isRemoteObject` is set to false and also checks should be made to ensure if a module introduces new properties with `isRemoteObject: false`.
-For more information and details of the behavior, refer to the readme.
+**CAUTION:** Setting this flag to `true`, on client side config, can cause all `isRemoteObject: false` properties set across the app (include properties set on modules if any) to be `true`. 
+So due diligence must be done before enabling this flag on client side. You should also be mindful of any future cases when `isRemoteObject: false` could be is set on other future module releases.
+For more information and details of the behavior, refer to the README.
 
 ## 9.3.0
 * defining schema type in persistor

--- a/components/persistor/README.md
+++ b/components/persistor/README.md
@@ -163,6 +163,20 @@ The account object connected to the fetched role is also automatically when a ro
                     "internalConsoleOptions": "openOnSessionStart"
                 }
         
+## Important features:
+### Version 7.4.0
+With this version we are introducing a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject` property on individual records, if they are set to false. This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true on the client side, you may override the behavior set by the module, and allow for docs to be saved in a remote s3 bucket.
+
+**Behavior:**
+if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
+if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
+if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
+if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in the remote s3 bucket.
+if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in db.
+if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
+if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
+if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in remote s3 bucket.
+if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
 
 ## License
 

--- a/components/persistor/README.md
+++ b/components/persistor/README.md
@@ -164,20 +164,24 @@ The account object connected to the fetched role is also automatically when a ro
                 }
         
 ## Important features:
-### Version 7.4.0
-With this version we are introducing a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject: false` properties on records. This feature is useful if you are using modules that may have properties set as `isRemoteObject: false` and you want to override that behavior. By setting this flag to `true` on the client side, you may override the behavior set by the module, and allow for docs to be saved in a remote s3 bucket. <br><br>
-**NOTE:** This is an all or nothing feature and client teams would need to be cautious using this feature.
+### Version 10.0.0
+With this version we are introducing a config `enableIsRemoteObjectFeature` as a required flag, to enable `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to true and client apps can safely upgrade to these modules without the requirement to also start using remoteStorage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to true in their respective config file(s). <br>
+**CAUTION:** This is an all or nothing flag. Once `enableIsRemoteObjectFeature` is set to true: 
+1. The `isRemoteObject` behavior defined on individual record properties will be enabled across your app (including the ones on your modules). 
+2. All properties where `isRemoteObject` is set to `true`, would need to be migrated to a remoteStorage, as going forward their retreival and storage would happen from remoteStorage. 
+3. If a client is already using isRemoteObject to send docs to remoteStorage, they must set `enableIsRemoteObjectFeature` this flag to true in their config. <br><br>
 
 **Behavior:**
-1. if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
-2. if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
-3. if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
-4. if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in the remote s3 bucket.
-5. if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in db.
-6. if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
-7. if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
-8. if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in remote s3 bucket.
-9. if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
+<br> Only the first scenario will result in storage to s3.
+1. if `isRemoteObject` is `true` and `enableIsRemoteObjectFeature` is `true` -> persistor will store in remote s3 bucket.
+2. if `isRemoteObject` is `false` and `enableIsRemoteObjectFeature` is `false` -> persistor will store in db.
+3. if `isRemoteObject` is `false` and `enableIsRemoteObjectFeature` is `true` -> persistor will store in db.
+4. if `isRemoteObject` is `true` and `enableIsRemoteObjectFeature` is `false` -> persistor will store in db.
+5. if `isRemoteObject` is `undefined` or not set on record property and `enableIsRemoteObjectFeature` is `true` -> persistor will store in db.
+6. if `isRemoteObject` is `undefined` or not set on record property and `enableIsRemoteObjectFeature` is `false` -> persistor will store in db.
+7. if `isRemoteObject` is `false` and `enableIsRemoteObjectFeature` is `undefined` or not set on client -> persistor will store in db.
+8. if `isRemoteObject` is `true` and `enableIsRemoteObjectFeature` is `undefined` or not set on client -> persistor will store in db.
+9. if `isRemoteObject` is `undefined` or not set on record property and `enableIsRemoteObjectFeature` is `undefined` or not set on client -> persistor will store in db.
 
 ## License
 

--- a/components/persistor/README.md
+++ b/components/persistor/README.md
@@ -165,11 +165,11 @@ The account object connected to the fetched role is also automatically when a ro
         
 ## Important features:
 ### Version 10.0.0
-With this version we are introducing a config `enableIsRemoteObjectFeature` as a required flag, to enable `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to true and client apps can safely upgrade to these modules without the requirement to also start using remoteStorage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to true in their respective config file(s). <br>
-**CAUTION:** This is an all or nothing flag. Once `enableIsRemoteObjectFeature` is set to true: 
+With this version we are introducing a config `enableIsRemoteObjectFeature` as a required flag, to enable `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to `true` and client apps can safely upgrade to these modules without the requirement to also start using remote storage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to `true` in their respective config file(s). <br>
+**CAUTION:** This is an all or nothing flag. Once `enableIsRemoteObjectFeature` is set to `true`: 
 1. The `isRemoteObject` behavior defined on individual record properties will be enabled across your app (including the ones on your modules). 
-2. All properties where `isRemoteObject` is set to `true`, would need to be migrated to a remoteStorage, as going forward their retreival and storage would happen from remoteStorage. 
-3. If a client is already using isRemoteObject to send docs to remoteStorage, they must set `enableIsRemoteObjectFeature` this flag to true in their config. <br><br>
+2. All properties where `isRemoteObject` is set to `true`, would need to be migrated to a remote storage, as going forward their retreival and storage would happen from remote storage. 
+3. If a client is already using `isRemoteObject` to send docs to remote storage, they must set `enableIsRemoteObjectFeature` this flag to `true` in their config. <br><br>
 
 **Behavior:**
 <br> Only the first scenario will result in storage to s3.

--- a/components/persistor/README.md
+++ b/components/persistor/README.md
@@ -165,18 +165,19 @@ The account object connected to the fetched role is also automatically when a ro
         
 ## Important features:
 ### Version 7.4.0
-With this version we are introducing a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject: false` properties on records. This feature is useful if you are using modules that may have properties set as `isRemoteObject: false` and you want to override that behavior. By setting this flag to `true` on the client side, you may override the behavior set by the module, and allow for docs to be saved in a remote s3 bucket. NOTE: This is an all or nothing feature and client teams would need to be cautious using this feature.
+With this version we are introducing a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject: false` properties on records. This feature is useful if you are using modules that may have properties set as `isRemoteObject: false` and you want to override that behavior. By setting this flag to `true` on the client side, you may override the behavior set by the module, and allow for docs to be saved in a remote s3 bucket. <br><br>
+**NOTE:** This is an all or nothing feature and client teams would need to be cautious using this feature.
 
 **Behavior:**
-if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
-if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
-if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
-if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in the remote s3 bucket.
-if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in db.
-if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
-if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
-if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in remote s3 bucket.
-if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
+1. if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
+2. if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
+3. if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.
+4. if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in the remote s3 bucket.
+5. if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in db.
+6. if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `false` -> persistor will store in db.
+7. if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
+8. if `isRemoteObject` is `true` and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in remote s3 bucket.
+9. if `isRemoteObject` is `undefined` or not set on record property and `globallyOverrideIsRemoteObjectProperties` is `undefined` or not set on client -> persistor will store in db.
 
 ## License
 

--- a/components/persistor/README.md
+++ b/components/persistor/README.md
@@ -165,7 +165,7 @@ The account object connected to the fetched role is also automatically when a ro
         
 ## Important features:
 ### Version 7.4.0
-With this version we are introducing a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject` property on individual records, if they are set to false. This feature is useful if you are using modules that have records that may be set as `isRemoteObject: false`. By setting this flag to true on the client side, you may override the behavior set by the module, and allow for docs to be saved in a remote s3 bucket.
+With this version we are introducing a config `globallyOverrideIsRemoteObjectProperties` as a feature, to override any or all `isRemoteObject: false` properties on records. This feature is useful if you are using modules that may have properties set as `isRemoteObject: false` and you want to override that behavior. By setting this flag to `true` on the client side, you may override the behavior set by the module, and allow for docs to be saved in a remote s3 bucket. NOTE: This is an all or nothing feature and client teams would need to be cautious using this feature.
 
 **Behavior:**
 if `isRemoteObject` is `false` and `globallyOverrideIsRemoteObjectProperties` is `true` -> persistor will store in the remote s3 bucket.

--- a/components/persistor/lib/knex/query.ts
+++ b/components/persistor/lib/knex/query.ts
@@ -250,7 +250,7 @@ module.exports = function (PersistObjectTemplate) {
                 defineProperty = props[prop];
                 var type = defineProperty.type;
                 var of = defineProperty.of;
-                const isRemoteDoc = PersistorUtils.isRemoteObjectSetToTrue(this.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject);
+                const isRemoteDoc = PersistorUtils.isRemoteObjectSetToTrue(this.config && this.config.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject);
                 var cascadeFetch = (cascade && typeof(cascade[prop] != 'undefined')) ? cascade[prop] : null;
                 if (cascadeFetch && cascadeFetch.fetch) {
                     Object.keys(cascadeFetch.fetch).map(key => {

--- a/components/persistor/lib/knex/query.ts
+++ b/components/persistor/lib/knex/query.ts
@@ -1,4 +1,5 @@
 import { RemoteDocService } from '../remote-doc/RemoteDocService';
+import { PersistorUtils } from '../utils/PersistorUtils';
 
 module.exports = function (PersistObjectTemplate) {
     const moduleName = `persistor/lib/knex/query`;
@@ -249,7 +250,7 @@ module.exports = function (PersistObjectTemplate) {
                 defineProperty = props[prop];
                 var type = defineProperty.type;
                 var of = defineProperty.of;
-                const isRemoteDoc = defineProperty.isRemoteObject;
+                const isRemoteDoc = PersistorUtils.isRemoteObjectSetToTrue(this.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject);
                 var cascadeFetch = (cascade && typeof(cascade[prop] != 'undefined')) ? cascade[prop] : null;
                 if (cascadeFetch && cascadeFetch.fetch) {
                     Object.keys(cascadeFetch.fetch).map(key => {

--- a/components/persistor/lib/knex/query.ts
+++ b/components/persistor/lib/knex/query.ts
@@ -250,7 +250,7 @@ module.exports = function (PersistObjectTemplate) {
                 defineProperty = props[prop];
                 var type = defineProperty.type;
                 var of = defineProperty.of;
-                const isRemoteDoc = PersistorUtils.isRemoteObjectSetToTrue(this.config && this.config.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject);
+                const isRemoteDoc = PersistorUtils.isRemoteObjectSetToTrue(this.config && this.config.enableIsRemoteObjectFeature, defineProperty.isRemoteObject);
                 var cascadeFetch = (cascade && typeof(cascade[prop] != 'undefined')) ? cascade[prop] : null;
                 if (cascadeFetch && cascadeFetch.fetch) {
                     Object.keys(cascadeFetch.fetch).map(key => {

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -160,7 +160,7 @@ module.exports = function (PersistObjectTemplate) {
 
                 dataSaved[foreignKey] = pojo[foreignKey] || 'null';
 
-            } else if (PersistorUtils.isRemoteObjectSetToTrue(this.config && this.config.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject)) {
+            } else if (PersistorUtils.isRemoteObjectSetToTrue(this.config && this.config.enableIsRemoteObjectFeature, defineProperty.isRemoteObject)) {
                 const uniqueIdentifier = obj._id;
 
                 // contents of the object itself

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -160,7 +160,7 @@ module.exports = function (PersistObjectTemplate) {
 
                 dataSaved[foreignKey] = pojo[foreignKey] || 'null';
 
-            } else if (PersistorUtils.isRemoteObjectSetToTrue(this.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject)) {
+            } else if (PersistorUtils.isRemoteObjectSetToTrue(this.config && this.config.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject)) {
                 const uniqueIdentifier = obj._id;
 
                 // contents of the object itself

--- a/components/persistor/lib/knex/update.ts
+++ b/components/persistor/lib/knex/update.ts
@@ -1,5 +1,6 @@
 import { RemoteDocService, UploadDocumentResponse } from '../remote-doc/RemoteDocService';
 import { PersistorTransaction } from '../types/PersistorTransaction';
+import { PersistorUtils } from '../utils/PersistorUtils';
 
 module.exports = function (PersistObjectTemplate) {
     const moduleName = `persistor/lib/knex/update`;
@@ -159,7 +160,7 @@ module.exports = function (PersistObjectTemplate) {
 
                 dataSaved[foreignKey] = pojo[foreignKey] || 'null';
 
-            } else if (defineProperty.isRemoteObject && defineProperty.isRemoteObject === true) {
+            } else if (PersistorUtils.isRemoteObjectSetToTrue(this.globallyOverrideIsRemoteObjectProperties, defineProperty.isRemoteObject)) {
                 const uniqueIdentifier = obj._id;
 
                 // contents of the object itself

--- a/components/persistor/lib/utils/PersistorUtils.ts
+++ b/components/persistor/lib/utils/PersistorUtils.ts
@@ -1,0 +1,8 @@
+export class PersistorUtils {
+
+    static isRemoteObjectSetToTrue(overrideIsRemoteObjectProperties: boolean, isRemoteObject: any): boolean  {
+        const shouldOverrideByConfig = overrideIsRemoteObjectProperties && isRemoteObject === false 
+                && overrideIsRemoteObjectProperties === true;
+        return shouldOverrideByConfig || (isRemoteObject && isRemoteObject === true);
+    }
+}

--- a/components/persistor/lib/utils/PersistorUtils.ts
+++ b/components/persistor/lib/utils/PersistorUtils.ts
@@ -1,11 +1,9 @@
 export class PersistorUtils {
 
-    static isRemoteObjectSetToTrue(overrideConfig: any, isRemoteObject: any): boolean  {
-        if (isRemoteObject === undefined || isRemoteObject === null) {
-            return;
+    static isRemoteObjectSetToTrue(enableIsRemoteObjectFeature: any, isRemoteObject: any): boolean  {
+        if (enableIsRemoteObjectFeature && (enableIsRemoteObjectFeature === true || enableIsRemoteObjectFeature === 'true')) {
+            return isRemoteObject && isRemoteObject === true;
         }
-        const shouldOverrideByConfig = overrideConfig && isRemoteObject === false 
-                && (overrideConfig === true || overrideConfig === 'true');
-        return shouldOverrideByConfig || (isRemoteObject && isRemoteObject === true);
+        return false;
     }
 }

--- a/components/persistor/lib/utils/PersistorUtils.ts
+++ b/components/persistor/lib/utils/PersistorUtils.ts
@@ -1,8 +1,11 @@
 export class PersistorUtils {
 
-    static isRemoteObjectSetToTrue(overrideIsRemoteObjectProperties: boolean, isRemoteObject: any): boolean  {
-        const shouldOverrideByConfig = overrideIsRemoteObjectProperties && isRemoteObject === false 
-                && overrideIsRemoteObjectProperties === true;
+    static isRemoteObjectSetToTrue(overrideConfig: any, isRemoteObject: any): boolean  {
+        if (isRemoteObject === undefined || isRemoteObject === null) {
+            return;
+        }
+        const shouldOverrideByConfig = overrideConfig && isRemoteObject === false 
+                && (overrideConfig === true || overrideConfig === 'true');
         return shouldOverrideByConfig || (isRemoteObject && isRemoteObject === true);
     }
 }

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1385,9 +1385,9 @@
             }
         },
         "node_modules/decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "engines": {
                 "node": ">=0.10"
             }
@@ -6560,9 +6560,9 @@
             "dev": true
         },
         "decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
         },
         "deep-eql": {
             "version": "3.0.1",

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@haventech/persistor",
-    "version": "9.4.0",
+    "version": "10.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@haventech/persistor",
-            "version": "9.4.0",
+            "version": "10.0.0",
             "dependencies": {
                 "aws-sdk": "2.x",
                 "bluebird": "x",

--- a/components/persistor/package-lock.json
+++ b/components/persistor/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@haventech/persistor",
-    "version": "9.3.0",
+    "version": "9.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@haventech/persistor",
-            "version": "9.3.0",
+            "version": "9.4.0",
             "dependencies": {
                 "aws-sdk": "2.x",
                 "bluebird": "x",

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@haventech/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "9.4.0",
+    "version": "10.0.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {

--- a/components/persistor/package.json
+++ b/components/persistor/package.json
@@ -2,7 +2,7 @@
     "name": "@haventech/persistor",
     "description": "A subclass of supertype that serializes to and reconstitutes from MongoDB or SQL databases",
     "homepage": "https://github.com/haven-life/persistor",
-    "version": "9.3.0",
+    "version": "9.4.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "dependencies": {

--- a/components/persistor/test/persist_banking_pgsql.js
+++ b/components/persistor/test/persist_banking_pgsql.js
@@ -20,7 +20,7 @@ const sandbox = sinon.createSandbox();
 PersistObjectTemplate.debugInfo = 'api;conflict;write;read;data';//'api;io';
 PersistObjectTemplate.debugInfo = 'conflict;data';//'api;io';
 PersistObjectTemplate.logger.setLevel(logLevel);
-PersistObjectTemplate.globallyOverrideIsRemoteObjectProperties = false;
+PersistObjectTemplate.config = { globallyOverrideIsRemoteObjectProperties: false };
 
 var Customer = PersistObjectTemplate.create('Customer', {
     init: function (first, middle, last) {
@@ -1240,7 +1240,7 @@ describe('Banking from pgsql Example persist_banking_pgsql', function () {
         const samRemoteDoc = await Customer.getFromPersistWithId(sam._id);
         samRemoteDoc.bankingDocument = 'bank note';
         sandbox.spy(LocalStorageDocClient.prototype, 'uploadDocument');
-        const overrideProperyStub = sinon.stub(PersistObjectTemplate, 'globallyOverrideIsRemoteObjectProperties').get(()=> {
+        const overrideProperyStub = sinon.stub(PersistObjectTemplate.config, 'globallyOverrideIsRemoteObjectProperties').get(()=> {
             return undefined;
         });
         await samRemoteDoc.persistSave();
@@ -1274,7 +1274,7 @@ describe('Banking from pgsql Example persist_banking_pgsql', function () {
         const addressId = accountOutput[1].address._id;
         const remoteDoc = await Address.getFromPersistWithId(addressId);
         remoteDoc.publicDocument = 'Deed Recording';
-        const overrideProperyStub = sinon.stub(PersistObjectTemplate, 'globallyOverrideIsRemoteObjectProperties').get(()=> {
+        const overrideProperyStub = sinon.stub(PersistObjectTemplate.config, 'globallyOverrideIsRemoteObjectProperties').get(()=> {
             return true;
         });
         sandbox.spy(LocalStorageDocClient.prototype, 'uploadDocument');
@@ -1297,7 +1297,7 @@ describe('Banking from pgsql Example persist_banking_pgsql', function () {
         const addressId = accountOutput[1].address._id;
         const remoteDoc = await Address.getFromPersistWithId(addressId);
         remoteDoc.publicDocument = 'Second Deed Recording';
-        const overrideProperyStub = sinon.stub(PersistObjectTemplate, 'globallyOverrideIsRemoteObjectProperties').get(()=> {
+        const overrideProperyStub = sinon.stub(PersistObjectTemplate.config, 'globallyOverrideIsRemoteObjectProperties').get(()=> {
             return undefined;
         });
         sandbox.spy(LocalStorageDocClient.prototype, 'uploadDocument');

--- a/components/persistor/test/persist_banking_s3.js
+++ b/components/persistor/test/persist_banking_s3.js
@@ -13,6 +13,7 @@ const logLevel = process.env.logLevel || 'debug';
 PersistObjectTemplate.debugInfo = 'api;conflict;write;read;data';//'api;io';
 PersistObjectTemplate.debugInfo = 'conflict;data';//'api;io';
 PersistObjectTemplate.logger.setLevel(logLevel);
+PersistObjectTemplate.config = { enableIsRemoteObjectFeature: true };
 
 const sandbox = sinon.createSandbox();
 


### PR DESCRIPTION
Adding a config `enableIsRemoteObjectFeature` as a required config, to allow `isRemoteObject` property to take effect. This is to allow modules to set their `isRemoteObject` flag to `true` and client apps can safely upgrade to these modules without the requirement to also start using remote storage. When clients are ready to take advantage of `isRemoteObject` property, they can simply set the `enableIsRemoteObjectFeature` config to `true` in their respective config file(s). <br>
**CAUTION:** This is an all or nothing flag. Once `enableIsRemoteObjectFeature` is set to `true` the `isRemoteObject` behavior defined on individual properties will be enabled in all places. 
For more information and details of the behavior, please refer to the `README`.