### PR TITLE
Persistor major bump to use `enableIsRemoteObjectFeature` config

### DIFF
--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,3 +1,6 @@
+## 11.3.0
+* Config `enableIsRemoteObjectFeature` is now a required config and must be set to `true`, if you are using remote storage(`isRemoteObject=true`) in your app (including packages and modules). Without this flag being set to `true`, the `isRemoteObject` property is supressed and cannot be used to send data to remote storage. You can still continue to send data to db however. 
+For more information and details of the behavior, please refer to the `Persistor's` `README` and `HISTORY` files.
 ## 11.2.1
 * setting formidable to a lower version for bug resolution. Will be setting it back to the latest at a later release.
 ## 11.2.0

--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,5 +1,5 @@
 ## 11.3.0
-* Config `enableIsRemoteObjectFeature` is now a required config and must be set to `true`, if you are using remote storage(`isRemoteObject=true`) in your app (including packages and modules). Without this flag being set to `true`, the `isRemoteObject` property is supressed and cannot be used to send data to remote storage. You can still continue to send data to db however. 
+* Config `enableIsRemoteObjectFeature` is now a required config and must be set to `true`, if you are using remote storage(`isRemoteObject=true`) in your app (including packages and modules). Without this flag being set to `true`, the `isRemoteObject` property is suppressed and cannot be used to send data to remote storage. You can still continue to send data to db however. 
 For more information and details of the behavior, please refer to the `Persistor's` `README` and `HISTORY` files.
 ## 11.2.1
 * setting formidable to a lower version for bug resolution. Will be setting it back to the latest at a later release.

--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -8,8 +8,8 @@
 			"name": "@haventech/amorphic",
 			"version": "11.2.1",
 			"dependencies": {
-				"@haventech/persistor": "9.x",
-				"@haventech/semotus": "7.x",
+				"@haventech/persistor": "^10.0.0",
+				"@haventech/semotus": "^7.1.0",
 				"@haventech/supertype": "^6.1.0",
 				"amorphic-bindster": "2.0.*",
 				"compression": "1.7.4",
@@ -418,9 +418,9 @@
 			"integrity": "sha512-j1NL+wUz9u3rC4IbIiNk6Wn0ObDG5Oh/LpNgGgMWNmE31YQgrg4Qf0lqZLHzd8lMTrB8eBd/ryJaUkok99aCBQ=="
 		},
 		"node_modules/@haventech/persistor": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-9.3.0.tgz",
-			"integrity": "sha512-Px+gR/m1FnQUbLe2yXlxhyd8hugLeycYDk77fCiHLeHQejBW4obR5geHy0XqaqVA1EIpWQsGeBG9diF9vL7Z/Q==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-10.0.0.tgz",
+			"integrity": "sha512-lUNkszennaj73w4dWpmNNeR6JKfda4BEx0RnURyNfk7uwAdUAQDHPKkgpQ7QFukuBpVVgSRo8gF2UHicAz88CA==",
 			"dependencies": {
 				"aws-sdk": "2.x",
 				"bluebird": "x",
@@ -1922,9 +1922,9 @@
 			}
 		},
 		"node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -7619,9 +7619,9 @@
 			"integrity": "sha512-j1NL+wUz9u3rC4IbIiNk6Wn0ObDG5Oh/LpNgGgMWNmE31YQgrg4Qf0lqZLHzd8lMTrB8eBd/ryJaUkok99aCBQ=="
 		},
 		"@haventech/persistor": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-9.3.0.tgz",
-			"integrity": "sha512-Px+gR/m1FnQUbLe2yXlxhyd8hugLeycYDk77fCiHLeHQejBW4obR5geHy0XqaqVA1EIpWQsGeBG9diF9vL7Z/Q==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-10.0.0.tgz",
+			"integrity": "sha512-lUNkszennaj73w4dWpmNNeR6JKfda4BEx0RnURyNfk7uwAdUAQDHPKkgpQ7QFukuBpVVgSRo8gF2UHicAz88CA==",
 			"requires": {
 				"aws-sdk": "2.x",
 				"bluebird": "x",
@@ -8817,9 +8817,9 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
 		},
 		"deep-eql": {
 			"version": "3.0.1",

--- a/components/amorphic/package.json
+++ b/components/amorphic/package.json
@@ -6,8 +6,8 @@
 	"types": "dist/index.d.ts",
 	"version": "11.2.1",
 	"dependencies": {
-		"@haventech/persistor": "9.x",
-		"@haventech/semotus": "7.x",
+		"@haventech/persistor": "^10.0.0",
+		"@haventech/semotus": "^7.1.0",
 		"@haventech/supertype": "^6.1.0",
 		"amorphic-bindster": "2.0.*",
 		"compression": "1.7.4",


### PR DESCRIPTION
Config `enableIsRemoteObjectFeature` is now a required config and must be set to `true`, if you are using remote storage(`isRemoteObject=true`) in your app (including packages and modules). Without this flag being set to `true`, the `isRemoteObject` property is suppressed and cannot be used to send data to remote storage. You can still continue to send data to db however. For more information and details of the behavior, please refer to the Persistor's `README` and `HISTORY` files.