### PR TITLE
Add back config to enable isRemoteObject property

### DIFF
--- a/components/amorphic/HISTORY.md
+++ b/components/amorphic/HISTORY.md
@@ -1,3 +1,7 @@
+## 12.0.0
+* Config `enableIsRemoteObjectFeature` is now a required config and must be set to `true`, if you are using remote storage(`isRemoteObject=true`) in your app (including packages and modules). Without this flag being set to `true`, the `isRemoteObject` property is suppressed and cannot be used to send data to remote storage. You can still continue to send data to db however. 
+For more information and details of the behavior, please refer to the `Persistor's` `README` and `HISTORY` files.
+NOTE: This change was previously introduced in version `11.3.0` only to be reverted in version `11.4.0`. It is being reintroduced as a major version bump in this version.
 ## 11.4.0
 * This change is reverting back the requirement to include the `enableIsRemoteObjectFeature` flag, to enable the `isRemoteObject` feature. This requirement was introduced by the persistor in version `10.0.0`, and amorphic previously incorporated the `10.0.0` persistor version in a minor version bump of amorphic (`11.3.0`). Since this could be a potential breaking change for some, best would be to revert this change in this minor version bump and instead re-introduce the change in the next major version. 
 ## 11.3.1

--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -1,14 +1,14 @@
 {
 	"name": "@haventech/amorphic",
-	"version": "11.4.0",
+	"version": "12.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@haventech/amorphic",
-			"version": "11.4.0",
+			"version": "12.0.0",
 			"dependencies": {
-				"@haventech/persistor": "^9.3.0",
+				"@haventech/persistor": "^10.0.0",
 				"@haventech/semotus": "^7.1.0",
 				"@haventech/supertype": "^6.1.0",
 				"amorphic-bindster": "2.0.*",
@@ -418,9 +418,9 @@
 			"integrity": "sha512-j1NL+wUz9u3rC4IbIiNk6Wn0ObDG5Oh/LpNgGgMWNmE31YQgrg4Qf0lqZLHzd8lMTrB8eBd/ryJaUkok99aCBQ=="
 		},
 		"node_modules/@haventech/persistor": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-9.3.0.tgz",
-			"integrity": "sha512-Px+gR/m1FnQUbLe2yXlxhyd8hugLeycYDk77fCiHLeHQejBW4obR5geHy0XqaqVA1EIpWQsGeBG9diF9vL7Z/Q==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-10.0.0.tgz",
+			"integrity": "sha512-lUNkszennaj73w4dWpmNNeR6JKfda4BEx0RnURyNfk7uwAdUAQDHPKkgpQ7QFukuBpVVgSRo8gF2UHicAz88CA==",
 			"dependencies": {
 				"aws-sdk": "2.x",
 				"bluebird": "x",
@@ -7607,9 +7607,9 @@
 			"integrity": "sha512-j1NL+wUz9u3rC4IbIiNk6Wn0ObDG5Oh/LpNgGgMWNmE31YQgrg4Qf0lqZLHzd8lMTrB8eBd/ryJaUkok99aCBQ=="
 		},
 		"@haventech/persistor": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-9.3.0.tgz",
-			"integrity": "sha512-Px+gR/m1FnQUbLe2yXlxhyd8hugLeycYDk77fCiHLeHQejBW4obR5geHy0XqaqVA1EIpWQsGeBG9diF9vL7Z/Q==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-10.0.0.tgz",
+			"integrity": "sha512-lUNkszennaj73w4dWpmNNeR6JKfda4BEx0RnURyNfk7uwAdUAQDHPKkgpQ7QFukuBpVVgSRo8gF2UHicAz88CA==",
 			"requires": {
 				"aws-sdk": "2.x",
 				"bluebird": "x",

--- a/components/amorphic/package.json
+++ b/components/amorphic/package.json
@@ -4,9 +4,9 @@
 	"homepage": "https://github.com/haven-life/amorphic",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"version": "11.4.0",
+	"version": "12.0.0",
 	"dependencies": {
-		"@haventech/persistor": "^9.3.0",
+		"@haventech/persistor": "^10.0.0",
 		"@haventech/semotus": "^7.1.0",
 		"@haventech/supertype": "^6.1.0",
 		"amorphic-bindster": "2.0.*",


### PR DESCRIPTION
Config `enableIsRemoteObjectFeature` is now a required config and must be set to `true`, if you are using remote storage(`isRemoteObject=true`) in your app (including packages and modules). Without this flag being set to `true`, the `isRemoteObject` property is suppressed and cannot be used to send data to remote storage. You can still continue to send data to db however. 
For more information and details of the behavior, please refer to the `Persistor's` `README` and `HISTORY` files.

NOTE: This change was previously introduced in version `11.3.0` only to be reverted in version `11.4.0`. It is being reintroduced as a major version bump in this version.