### PR TITLE
draft: feat: support importing ES modules

### DIFF
--- a/components/amorphic/lib/AmorphicServer.ts
+++ b/components/amorphic/lib/AmorphicServer.ts
@@ -60,7 +60,7 @@ export class AmorphicServer {
     * @param appDirectory - Location of the apps folder
     * @param sessionConfig - Object containing the session config
     */
-    static createServer(preSessionInject, postSessionInject, appList, appStartList, appDirectory, sessionConfig) {
+    static async createServer(preSessionInject, postSessionInject, appList, appStartList, appDirectory, sessionConfig) {
         const amorphicOptions = AmorphicContext.amorphicOptions;
         const mainApp = amorphicOptions.mainApp;
         const appConfig = AmorphicContext.applicationConfig[mainApp];
@@ -84,7 +84,7 @@ export class AmorphicServer {
 
         const apiPath = serverOptions && serverOptions.apiPath;
 
-        server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
+        await server.setupUserEndpoints(appDirectory, appList[mainApp], apiPath);
 
         // for anything other than user only routes, set up our default amorphic router.
         if (server.serverMode !== 'api') {
@@ -324,10 +324,10 @@ export class AmorphicServer {
      * for amorphic is for the '/amorphic' routes to run
      * @memberof AmorphicServer
      */
-    setupUserEndpoints(appDirectory: string, mainAppPath: string, apiPath = '/api') {
+    async setupUserEndpoints(appDirectory: string, mainAppPath: string, apiPath = '/api') {
         let filePath = this.getBaseControllerFilePath(appDirectory, mainAppPath);
-        let router = setupCustomMiddlewares(filePath, express.Router());
-        router = setupCustomRoutes(filePath, router);
+        let router = await setupCustomMiddlewares(filePath, express.Router());
+        router = await setupCustomRoutes(filePath, router);
 
         if (router) {
             this.app.use(apiPath, router);

--- a/components/amorphic/lib/setupCustomMiddlewares.js
+++ b/components/amorphic/lib/setupCustomMiddlewares.js
@@ -6,14 +6,14 @@ const fs = require('fs');
 
 const moduleName = `amorphic/lib/setupCustomMiddlewares`;
 
-function setupCustomMiddlewares(filePath, router) {
+async function setupCustomMiddlewares(filePath, router) {
     const functionName = setupCustomMiddlewares.name;
     const middlewareFilePath = `${filePath}/middlewares/index.js`;
 
     let middlewares;
 
     if(fs.existsSync(middlewareFilePath)) {
-        middlewares = require(middlewareFilePath);
+        middlewares = await import(middlewareFilePath);
 
         const exportedMiddlewareFunctions = Object.keys(middlewares);
 

--- a/components/amorphic/lib/setupCustomRoutes.js
+++ b/components/amorphic/lib/setupCustomRoutes.js
@@ -6,14 +6,14 @@ const fs = require('fs');
 
 const moduleName = `amorphic/lib/setupCustomRoutes`;
 
-function setupCustomRoutes(filePath, router) {
+async function setupCustomRoutes(filePath, router) {
     const functionName = setupCustomRoutes.name;
     const routerFilePath = `${filePath}/routers/index.js`;
 
     let routers;
 
     if(fs.existsSync(routerFilePath)) {
-        routers = require(routerFilePath);
+        routers = await import(routerFilePath);
 
         const exportedRouterFunctions = Object.keys(routers);
 

--- a/components/amorphic/lib/startApplication.js
+++ b/components/amorphic/lib/startApplication.js
@@ -287,7 +287,7 @@ function loadTemplates(appName) {
  *
  * @returns {[Object, Object]} unknown
  */
-function loadTSTemplates(appName) {
+async function loadTSTemplates(appName) {
 
     let appConfig = AmorphicContext.applicationConfig[appName] || {};
     let controllerPath = (appConfig.appConfig.controller || 'controller.js');
@@ -306,7 +306,7 @@ function loadTSTemplates(appName) {
     require('../index.js').bindDecorators(baseTemplate);
 
     // TODO: Typescript - this assumes that .js is in same directory as .ts but probably should be looking at tsconfig
-    AmorphicContext.applicationTSController[appName] = require(appConfig.appPath + '/' + controllerPath).Controller;
+    AmorphicContext.applicationTSController[appName] = await import(appConfig.appPath + '/' + controllerPath).then(m => m.Controller);
 
     checkTypes(baseTemplate.getClasses());
     baseTemplate.performInjections();


### PR DESCRIPTION
- use dynamic import instead of require in:
  - `loadTSTemplates`
  - `setupCustomMiddlewares`
  - `setupCustomRoutes`

```
Error [ERR_REQUIRE_ESM]: require() of ES Module apps/startup/js/Controller.js from amorphic/dist/lib/startApplication.js not supported.
Instead change the require of Controller.js in amorphic/dist/lib/startApplication.js to a dynamic import() which is available in all CommonJS modules.
```

TODOs:
- [ ] convert to async/await to promise chains