### PR TITLE
Patched Fix MongoDB Driver may publish events containing authenticati…

### DIFF
--- a/components/amorphic/package-lock.json
+++ b/components/amorphic/package-lock.json
@@ -62,45 +62,13 @@
 				"pg": ">=8.7.0 <9.0.0"
 			}
 		},
-		".yalc/@haventech/persistor": {
-			"version": "13.0.0",
-			"dependencies": {
-				"aws-sdk": "2.x",
-				"bluebird": "x",
-				"mongodb": "^3.5.5",
-				"q": "1.x",
-				"run": "^1.4.0",
-				"test": "^3.2.1",
-				"tv4": "^1.3.0",
-				"underscore": "^1.13.1"
-			},
-			"engines": {
-				"node": ">=16.x"
-			},
-			"peerDependencies": {
-				"@haventech/supertype": "^8.0.0",
-				"knex": ">=0.21.0 <3.0.0",
-				"pg": ">=8.7.0 <9.0.0"
-			}
-		},
-		".yalc/@haventech/semotus": {
-			"version": "10.0.0",
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"@haventech/supertype": "^8.0.0"
-			}
-		},
 		".yalc/@haventech/supertype": {
-			"version": "9.0.0",
+			"version": "0.0.1",
+			"extraneous": true,
 			"dependencies": {
 				"@haventech/amorphic-contracts": "^0.2.0",
 				"nconf": "^0.12.0",
 				"reflect-metadata": "^0.1.13"
-			},
-			"engines": {
-				"node": ">=16.x"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1976,16 +1944,51 @@
 			"integrity": "sha512-j1NL+wUz9u3rC4IbIiNk6Wn0ObDG5Oh/LpNgGgMWNmE31YQgrg4Qf0lqZLHzd8lMTrB8eBd/ryJaUkok99aCBQ=="
 		},
 		"node_modules/@haventech/persistor": {
-			"resolved": ".yalc/@haventech/persistor",
-			"link": true
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-13.0.1.tgz",
+			"integrity": "sha512-zSPgIKyAvhBAQyBdZT5cnGWte347DdvBIWPIBMaVL5esHlxWr0HIACwjMRxcs/cIvZIVnGH+s/O6fLpFb/ipGQ==",
+			"dependencies": {
+				"aws-sdk": "2.x",
+				"bluebird": "x",
+				"mongodb": "^3.5.5",
+				"q": "1.x",
+				"run": "^1.4.0",
+				"test": "^3.2.1",
+				"tv4": "^1.3.0",
+				"underscore": "^1.13.1"
+			},
+			"engines": {
+				"node": ">=16.x"
+			},
+			"peerDependencies": {
+				"@haventech/supertype": "^9.0.2",
+				"knex": ">=0.21.0 <3.0.0",
+				"pg": ">=8.7.0 <9.0.0"
+			}
 		},
 		"node_modules/@haventech/semotus": {
-			"resolved": ".yalc/@haventech/semotus",
-			"link": true
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@haventech/semotus/-/semotus-10.0.1.tgz",
+			"integrity": "sha512-id6lno/K3SQG4bnbfaaCqUHSQXCOBLgSw3d0tbdE9mw/ArLo14Ri26Ax+Mkg2c/2ThlJaWH3ipbUTs+yIGvYag==",
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@haventech/supertype": "^9.0.2"
+			}
 		},
 		"node_modules/@haventech/supertype": {
-			"resolved": ".yalc/@haventech/supertype",
-			"link": true
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@haventech/supertype/-/supertype-9.0.2.tgz",
+			"integrity": "sha512-bgfDj5275Ube4zRDgfXUDkNUZILOzUKSOWcVJQ0AAueXytFV+J2cQw9pvhKKkl2UqMeWcF+c/dzLMna6OSR11A==",
+			"dependencies": {
+				"@haventech/amorphic-contracts": "^0.2.0",
+				"nconf": "^0.12.0",
+				"reflect-metadata": "^0.1.13"
+			},
+			"engines": {
+				"node": ">=16.x"
+			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -5784,14 +5787,14 @@
 			}
 		},
 		"node_modules/mongodb": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.5.tgz",
-			"integrity": "sha512-mQlYKw1iGbvJJejcPuyTaytq0xxlYbIoVDm2FODR+OHxyEiMR021vc32bTvamgBjCswsD54XIRwhg3yBaWqJjg==",
+			"version": "3.6.10",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.10.tgz",
+			"integrity": "sha512-fvIBQBF7KwCJnDZUnFFy4WqEFP8ibdXeFANnylW19+vOwdjOAvqIzPdsNCEMT6VKTHnYu4K64AWRih0mkFms6Q==",
 			"dependencies": {
 				"bl": "^2.2.1",
 				"bson": "^1.1.4",
 				"denque": "^1.4.1",
-				"require_optional": "^1.0.1",
+				"optional-require": "^1.0.3",
 				"safe-buffer": "^5.1.2"
 			},
 			"engines": {
@@ -6192,6 +6195,17 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/optional-require": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+			"integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+			"dependencies": {
+				"require-at": "^1.0.6"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/optionator": {
@@ -6906,13 +6920,12 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/require_optional": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"dependencies": {
-				"resolve-from": "^2.0.0",
-				"semver": "^5.1.0"
+		"node_modules/require-at": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+			"integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/require-directory": {
@@ -6943,14 +6956,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/reusify": {
@@ -7078,6 +7083,7 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
 			}
@@ -9557,7 +9563,9 @@
 			"integrity": "sha512-j1NL+wUz9u3rC4IbIiNk6Wn0ObDG5Oh/LpNgGgMWNmE31YQgrg4Qf0lqZLHzd8lMTrB8eBd/ryJaUkok99aCBQ=="
 		},
 		"@haventech/persistor": {
-			"version": "file:.yalc/@haventech/persistor",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/@haventech/persistor/-/persistor-13.0.1.tgz",
+			"integrity": "sha512-zSPgIKyAvhBAQyBdZT5cnGWte347DdvBIWPIBMaVL5esHlxWr0HIACwjMRxcs/cIvZIVnGH+s/O6fLpFb/ipGQ==",
 			"requires": {
 				"aws-sdk": "2.x",
 				"bluebird": "x",
@@ -9570,11 +9578,15 @@
 			}
 		},
 		"@haventech/semotus": {
-			"version": "file:.yalc/@haventech/semotus",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@haventech/semotus/-/semotus-10.0.1.tgz",
+			"integrity": "sha512-id6lno/K3SQG4bnbfaaCqUHSQXCOBLgSw3d0tbdE9mw/ArLo14Ri26Ax+Mkg2c/2ThlJaWH3ipbUTs+yIGvYag==",
 			"requires": {}
 		},
 		"@haventech/supertype": {
-			"version": "file:.yalc/@haventech/supertype",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@haventech/supertype/-/supertype-9.0.2.tgz",
+			"integrity": "sha512-bgfDj5275Ube4zRDgfXUDkNUZILOzUKSOWcVJQ0AAueXytFV+J2cQw9pvhKKkl2UqMeWcF+c/dzLMna6OSR11A==",
 			"requires": {
 				"@haventech/amorphic-contracts": "^0.2.0",
 				"nconf": "^0.12.0",
@@ -12434,14 +12446,14 @@
 			"dev": true
 		},
 		"mongodb": {
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.5.tgz",
-			"integrity": "sha512-mQlYKw1iGbvJJejcPuyTaytq0xxlYbIoVDm2FODR+OHxyEiMR021vc32bTvamgBjCswsD54XIRwhg3yBaWqJjg==",
+			"version": "3.6.10",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.10.tgz",
+			"integrity": "sha512-fvIBQBF7KwCJnDZUnFFy4WqEFP8ibdXeFANnylW19+vOwdjOAvqIzPdsNCEMT6VKTHnYu4K64AWRih0mkFms6Q==",
 			"requires": {
 				"bl": "^2.2.1",
 				"bson": "^1.1.4",
 				"denque": "^1.4.1",
-				"require_optional": "^1.0.1",
+				"optional-require": "^1.0.3",
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
 			}
@@ -12742,6 +12754,14 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"optional-require": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+			"integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+			"requires": {
+				"require-at": "^1.0.6"
 			}
 		},
 		"optionator": {
@@ -13283,14 +13303,10 @@
 				"uuid": "^3.3.2"
 			}
 		},
-		"require_optional": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"requires": {
-				"resolve-from": "^2.0.0",
-				"semver": "^5.1.0"
-			}
+		"require-at": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+			"integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -13312,11 +13328,6 @@
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
-		},
-		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -13392,7 +13403,8 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
 		},
 		"send": {
 			"version": "0.18.0",


### PR DESCRIPTION
…on-related data

**Descriptions:**
Some MongoDB Drivers may erroneously publish events containing authentication-related data to a command listener configured by an application. The published events may contain security-sensitive data when specific authentication-related commands are executed.

Without due care, an application may inadvertently expose this sensitive information, e.g., by writing it to a log file. This issue only arises if an application enables the command listener feature (this is not enabled by default). This issue affects the MongoDB C Driver 1.0.0 prior to 1.17.7, MongoDB PHP Driver 1.0.0 prior to 1.9.2, MongoDB Swift Driver 1.0.0 prior to 1.1.1, MongoDB Node.js Driver 3.6 prior to 3.6.10, MongoDB Node.js Driver 4.0 prior to 4.17.0 and MongoDB Node.js Driver 5.0 prior to 5.8.0. This issue also affects users of the MongoDB C++ Driver dependent on the C driver 1.0.0 prior to 1.17.7 (C++ driver prior to 3.7.0).

```c
/*
 * An example showing command monitoring for a sensitive command: "getnonce".
 * Compile with:
 * clang no-redaction.c -o no-redaction $(pkg-config --cflags --libs libmongoc-1.0)
 * Run with:
 * ./no-redaction [CONNECTION_STRING]
 */

#include <mongoc/mongoc.h>
#include <stdio.h>

void
command_started (const mongoc_apm_command_started_t *event)
{
   char *s;

   s = bson_as_relaxed_extended_json (
      mongoc_apm_command_started_get_command (event), NULL);
   printf ("Command %s started on %s:\n%s\n\n",
           mongoc_apm_command_started_get_command_name (event),
           mongoc_apm_command_started_get_host (event)->host,
           s);

   bson_free (s);
}


void
command_succeeded (const mongoc_apm_command_succeeded_t *event)
{
   char *s;

   s = bson_as_relaxed_extended_json (
      mongoc_apm_command_succeeded_get_reply (event), NULL);
   printf ("Command %s succeeded:\n%s\n\n",
           mongoc_apm_command_succeeded_get_command_name (event),
           s);

   bson_free (s);
}


void
command_failed (const mongoc_apm_command_failed_t *event)
{
   bson_error_t error;

   mongoc_apm_command_failed_get_error (event, &error);
   printf ("Command %s failed:\n\"%s\"\n\n",
           mongoc_apm_command_failed_get_command_name (event),
           error.message);
}


int
main (int argc, char *argv[])
{
   mongoc_client_t *client;
   mongoc_database_t *db;
   mongoc_collection_t *coll;
   mongoc_apm_callbacks_t *callbacks;
   bson_error_t error;
   const char *uri_string = "mongodb://localhost/?appname=cmd-monitoring-example";
   mongoc_uri_t *uri;
   bson_t *cmd;

   mongoc_init ();

   if (argc > 1) {
      uri_string = argv[1];
   }

   uri = mongoc_uri_new_with_error (uri_string, &error);
   if (!uri) {
      fprintf (stderr,
               "failed to parse URI: %s\n"
               "error message:       %s\n",
               uri_string,
               error.message);
      return EXIT_FAILURE;
   }

   client = mongoc_client_new_from_uri (uri);
   if (!client) {
      return EXIT_FAILURE;
   }

   mongoc_client_set_error_api (client, 2);
   callbacks = mongoc_apm_callbacks_new ();
   mongoc_apm_set_command_started_cb (callbacks, command_started);
   mongoc_apm_set_command_succeeded_cb (callbacks, command_succeeded);
   mongoc_apm_set_command_failed_cb (callbacks, command_failed);
   mongoc_client_set_apm_callbacks (client, callbacks, NULL);

   db = mongoc_client_get_database (client, "db");
   coll = mongoc_database_get_collection (db, "coll");

   cmd = BCON_NEW ("getnonce", BCON_INT32(1));
   mongoc_client_command_simple (client, "db", cmd, NULL /* read prefs */, NULL /* reply */, &error);
   bson_destroy (cmd);
   
   mongoc_apm_callbacks_destroy (callbacks);
   mongoc_uri_destroy (uri);
   mongoc_collection_destroy (coll);
   mongoc_database_destroy (db);
   mongoc_client_destroy (client);

   mongoc_cleanup ();

   return EXIT_SUCCESS;
}
```
```js
const maybeRedact = (commandName, result) => (SENSITIVE_COMMANDS.has(commandName) ? {} : result);
  // NOTE: remove in major revision, this is not spec behavior
    if (SENSITIVE_COMMANDS.has(commandName)) {
      this.commandObj = {};
      this.commandObj[commandName] = true;
    }
```
```js
      // TODO: NODE-3356 unskip redaction tests
      const testsToSkip =
        loadedSpec.description === 'redacted-commands'
          ? loadedSpec.tests
              .map(test => test.description)
              .filter(
                description =>
                  description !== 'hello without speculative authenticate is not redacted'
              )
          : [];
```
CVE-2021-32050
CWE-200
CWE-532
`CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:N/A:N`